### PR TITLE
MHLabel 커스텀 구현 (= 온글잎 베리려원 폰트 적용된 Label)

### DIFF
--- a/MemorialHouse/MHPresentation/MHPresentation.xcodeproj/project.pbxproj
+++ b/MemorialHouse/MHPresentation/MHPresentation.xcodeproj/project.pbxproj
@@ -7,15 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		CE9AEBA82CD7B50600F8471D /* Temp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9AEBA72CD7B50600F8471D /* Temp.swift */; };
+		0E7F28E82CDA6B90007D4F2B /* 온글잎 베리려원.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0E7F28E72CDA6B90007D4F2B /* 온글잎 베리려원.ttf */; };
+		0E7F28EF2CDA6C3A007D4F2B /* MHLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7F28EE2CDA6C3A007D4F2B /* MHLabel.swift */; };
 		CE9AEBAB2CD7B51D00F8471D /* MHDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE9AEBAA2CD7B51D00F8471D /* MHDomain.framework */; };
 		CE9AEBFA2CD7BA2000F8471D /* MHCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE9AEBF92CD7BA2000F8471D /* MHCore.framework */; };
 		DB382CC52CD9B22E000D7689 /* MHFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB382CC42CD9B22E000D7689 /* MHFoundation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0E7F28E72CDA6B90007D4F2B /* 온글잎 베리려원.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "온글잎 베리려원.ttf"; sourceTree = "<group>"; };
+		0E7F28EC2CDA6C06007D4F2B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0E7F28EE2CDA6C3A007D4F2B /* MHLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MHLabel.swift; sourceTree = "<group>"; };
 		CE9AEB992CD7B4F200F8471D /* MHPresentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MHPresentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CE9AEBA72CD7B50600F8471D /* Temp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Temp.swift; sourceTree = "<group>"; };
 		CE9AEBAA2CD7B51D00F8471D /* MHDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MHDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE9AEBF92CD7BA2000F8471D /* MHCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MHCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DB382CC42CD9B22E000D7689 /* MHFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MHFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -35,6 +38,39 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0E7F28E52CDA6B5E007D4F2B /* Resource */ = {
+			isa = PBXGroup;
+			children = (
+				0E7F28EC2CDA6C06007D4F2B /* Info.plist */,
+				0E7F28E92CDA6B92007D4F2B /* Fonts */,
+			);
+			path = Resource;
+			sourceTree = "<group>";
+		};
+		0E7F28E62CDA6B63007D4F2B /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				0E7F28ED2CDA6C21007D4F2B /* Design */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+		0E7F28E92CDA6B92007D4F2B /* Fonts */ = {
+			isa = PBXGroup;
+			children = (
+				0E7F28E72CDA6B90007D4F2B /* 온글잎 베리려원.ttf */,
+			);
+			path = Fonts;
+			sourceTree = "<group>";
+		};
+		0E7F28ED2CDA6C21007D4F2B /* Design */ = {
+			isa = PBXGroup;
+			children = (
+				0E7F28EE2CDA6C3A007D4F2B /* MHLabel.swift */,
+			);
+			path = Design;
+			sourceTree = "<group>";
+		};
 		CE9AEB8F2CD7B4F200F8471D = {
 			isa = PBXGroup;
 			children = (
@@ -55,7 +91,8 @@
 		CE9AEBA52CD7B4FA00F8471D /* MHPresentation */ = {
 			isa = PBXGroup;
 			children = (
-				CE9AEBA72CD7B50600F8471D /* Temp.swift */,
+				0E7F28E52CDA6B5E007D4F2B /* Resource */,
+				0E7F28E62CDA6B63007D4F2B /* Source */,
 			);
 			path = MHPresentation;
 			sourceTree = "<group>";
@@ -146,6 +183,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0E7F28E82CDA6B90007D4F2B /* 온글잎 베리려원.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,7 +214,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CE9AEBA82CD7B50600F8471D /* Temp.swift in Sources */,
+				0E7F28EF2CDA6C3A007D4F2B /* MHLabel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -198,6 +236,7 @@
 				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MHPresentation/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -239,6 +278,7 @@
 				ENABLE_MODULE_VERIFIER = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MHPresentation/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;

--- a/MemorialHouse/MHPresentation/MHPresentation/Resource/Info.plist
+++ b/MemorialHouse/MHPresentation/MHPresentation/Resource/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>온글잎 베리려원.ttf</string>
+	</array>
+</dict>
+</plist>

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHLabel.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHLabel.swift
@@ -1,9 +1,10 @@
 import UIKit
 
 final class MHLabel: UILabel {
+    private var labelText: String
+    private var size: CGFloat
     private let alignment: NSTextAlignment
     private var color: UIColor
-    private var labelText: String
     
     /// - Parameters:
     ///   - frame: 레이블의 프레임. 기본값은 `.zero`입니다.
@@ -14,15 +15,17 @@ final class MHLabel: UILabel {
     init(
         frame: CGRect = .zero,
         labelText: String = "",
+        size: CGFloat = 25,
         alignment: NSTextAlignment = .justified,
         color: UIColor = .black
     ) {
         self.labelText = labelText
+        self.size = size
         self.alignment = alignment
         self.color = color
         super.init(frame: frame)
         
-        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: 25) else { return }
+        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: size) else { return }
         self.font = font
         setupAttributes()
     }
@@ -30,11 +33,12 @@ final class MHLabel: UILabel {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         self.labelText = ""
+        self.size = 25
         self.alignment = .justified
         self.color = .black
         super.init(coder: coder)
         
-        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: 25) else { return }
+        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: size) else { return }
         self.font = font
         setupAttributes()
     }
@@ -44,7 +48,7 @@ final class MHLabel: UILabel {
         let range = NSRange(location: 0, length: attributedString.length)
         
         // 폰트 설정
-        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: 25) else { return }
+        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: size) else { return }
         attributedString.addAttribute(
             .font,
             value: font,

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHLabel.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHLabel.swift
@@ -6,6 +6,10 @@ final class MHLabel: UILabel {
     private let alignment: NSTextAlignment
     private var color: UIColor
     
+    private var customFont: UIFont? {
+        return UIFont(name: "Ownglyph_BERRY_RW-Rg", size: size)
+    }
+    
     /// - Parameters:
     ///   - frame: 레이블의 프레임. 기본값은 `.zero`입니다.
     ///   - labelText: 레이블에 표시될 텍스트. 기본값은 빈 문자열입니다.
@@ -24,9 +28,7 @@ final class MHLabel: UILabel {
         self.alignment = alignment
         self.color = color
         super.init(frame: frame)
-        
-        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: size) else { return }
-        self.font = font
+        self.font = customFont
         setupAttributes()
     }
     
@@ -37,9 +39,7 @@ final class MHLabel: UILabel {
         self.alignment = .justified
         self.color = .black
         super.init(coder: coder)
-        
-        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: size) else { return }
-        self.font = font
+        self.font = customFont
         setupAttributes()
     }
     
@@ -48,12 +48,13 @@ final class MHLabel: UILabel {
         let range = NSRange(location: 0, length: attributedString.length)
         
         // 폰트 설정
-        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: size) else { return }
-        attributedString.addAttribute(
-            .font,
-            value: font,
-            range: range
-        )
+        if let font = customFont {
+            attributedString.addAttribute(
+                .font,
+                value: font,
+                range: range
+            )
+        }
         
         // 텍스트 색상 설정
         attributedString.addAttribute(

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHLabel.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHLabel.swift
@@ -1,10 +1,10 @@
 import UIKit
 
 final class MHLabel: UILabel {
-    private var labelText: String
-    private var size: CGFloat
+    private let labelText: String
+    private let size: CGFloat
     private let alignment: NSTextAlignment
-    private var color: UIColor
+    private let color: UIColor
     
     private var customFont: UIFont? {
         return UIFont(name: "Ownglyph_BERRY_RW-Rg", size: size)
@@ -13,9 +13,9 @@ final class MHLabel: UILabel {
     /// - Parameters:
     ///   - frame: 레이블의 프레임. 기본값은 `.zero`입니다.
     ///   - labelText: 레이블에 표시될 텍스트. 기본값은 빈 문자열입니다.
+    ///   - size: 레이블 텍스트의 크기. 기본값은 25입니다.
     ///   - alignment: 텍스트 정렬 방식. 기본값은 `.justified`입니다.
     ///   - color: 텍스트 색상. 기본값은 `UIColor.black`입니다.
-    
     init(
         frame: CGRect = .zero,
         labelText: String = "",
@@ -29,7 +29,7 @@ final class MHLabel: UILabel {
         self.color = color
         super.init(frame: frame)
         self.font = customFont
-        setupAttributes()
+        setup()
     }
     
     @available(*, unavailable)
@@ -40,38 +40,13 @@ final class MHLabel: UILabel {
         self.color = .black
         super.init(coder: coder)
         self.font = customFont
-        setupAttributes()
+        setup()
     }
     
-    private func setupAttributes() {
-        let attributedString = NSMutableAttributedString(string: labelText)
-        let range = NSRange(location: 0, length: attributedString.length)
-        
-        // 폰트 설정
-        if let font = customFont {
-            attributedString.addAttribute(
-                .font,
-                value: font,
-                range: range
-            )
-        }
-        
-        // 텍스트 색상 설정
-        attributedString.addAttribute(
-            .foregroundColor,
-            value: color,
-            range: range
-        )
-        
-        // 텍스트 정렬 설정
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.alignment = alignment
-        attributedString.addAttribute(
-            .paragraphStyle,
-            value: paragraphStyle,
-            range: range
-        )
-        
-        attributedText = attributedString
+    private func setup() {
+        self.font = customFont
+        self.textColor = color
+        self.textAlignment = alignment
+        self.text = labelText
     }
 }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHLabel.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHLabel.swift
@@ -1,0 +1,72 @@
+import UIKit
+
+final class MHLabel: UILabel {
+    private let alignment: NSTextAlignment
+    private var color: UIColor
+    private var labelText: String
+    
+    /// - Parameters:
+    ///   - frame: 레이블의 프레임. 기본값은 `.zero`입니다.
+    ///   - labelText: 레이블에 표시될 텍스트. 기본값은 빈 문자열입니다.
+    ///   - alignment: 텍스트 정렬 방식. 기본값은 `.justified`입니다.
+    ///   - color: 텍스트 색상. 기본값은 `UIColor.black`입니다.
+    
+    init(
+        frame: CGRect = .zero,
+        labelText: String = "",
+        alignment: NSTextAlignment = .justified,
+        color: UIColor = .black
+    ) {
+        self.labelText = labelText
+        self.alignment = alignment
+        self.color = color
+        super.init(frame: frame)
+        
+        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: 25) else { return }
+        self.font = font
+        setupAttributes()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        self.labelText = ""
+        self.alignment = .justified
+        self.color = .black
+        super.init(coder: coder)
+        
+        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: 25) else { return }
+        self.font = font
+        setupAttributes()
+    }
+    
+    private func setupAttributes() {
+        let attributedString = NSMutableAttributedString(string: labelText)
+        let range = NSRange(location: 0, length: attributedString.length)
+        
+        // 폰트 설정
+        guard let font = UIFont(name: "Ownglyph_BERRY_RW-Rg", size: 25) else { return }
+        attributedString.addAttribute(
+            .font,
+            value: font,
+            range: range
+        )
+        
+        // 텍스트 색상 설정
+        attributedString.addAttribute(
+            .foregroundColor,
+            value: color,
+            range: range
+        )
+        
+        // 텍스트 정렬 설정
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = alignment
+        attributedString.addAttribute(
+            .paragraphStyle,
+            value: paragraphStyle,
+            range: range
+        )
+        
+        attributedText = attributedString
+    }
+}

--- a/MemorialHouse/MHPresentation/MHPresentation/Temp.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Temp.swift
@@ -1,8 +1,0 @@
-//
-//  Temp.swift
-//  MHPresentation
-//
-//  Created by 임정현 on 11/3/24.
-//
-
-import Foundation


### PR DESCRIPTION
### 논의 결과 UIView의 Convenience init을 추가하는 것으로 결정

<br>

<details>
<summary><h3>이전 PR 내역 열어보기</h3></summary>

## #️⃣ 연관된 이슈
#14 

<br>

## 📝 작업 내용
<!-- 본 PR에서 작업한 내용을 적어주세요 -->
- 온글잎 베리려원 폰트 적용된 커스텀 MHLabel 구현

<br>

## 📒 리뷰 노트
<!-- 본 PR과 관련하여 특이사항이 있다면 알려주세요 -->
사용 예시입니다
``` swift
let label1 = MHLabel(labelText: "집주인 출판소1")
let label2 = MHLabel(labelText: "집주인 출판소2", color: .white)
let label3 = MHLabel(labelText: "집주인 출판소3", alignment: .right, color: .white)
```
<img width="403" alt="스크린샷 2024-11-06 오전 12 21 46" src="https://github.com/user-attachments/assets/9fccae5d-6247-4713-8925-3905d11c994d">


<br>

## ⚽️ 트러블 슈팅
<!-- 개발 과정에서 발생한 문제를 노션에 작성하고, 그 내용을 여기에도 올려주세요 ! -->
1. `온글잎 베리려원.ttf`을 Xcode에 넣는다고 되는게 아니라 info.plist에 `Fonts provided by application`로 넣어줘야 함
2. 한글로 된 "온글잎 베리려원.ttf"를 넣으니 Xcode가 이름을 `Ownglyph_BERRY_RW-Rg`로 바꿔버림 (ㅂㄷㅂㄷ)
아래 코드로 찾아서 해결했습니다.
	``` swift
    for family in UIFont.familyNames {
        print("Family: \(family)")
        for name in UIFont.fontNames(forFamilyName: family) {
            print("  \(name)")
        }
    }
	```
	<img width="295" alt="스크린샷 2024-11-06 오전 12 00 01" src="https://github.com/user-attachments/assets/9d93217f-7990-4422-869b-d030045d2b17">


<br>

## 📸 스크린샷
<!-- 스크린샷 or 영상으로 PR을 설명해주세요 -->
<img width="1436" alt="스크린샷 2024-11-06 오전 12 15 51" src="https://github.com/user-attachments/assets/fa4ff2ea-9d6e-4dcc-bb1c-594575a62dd6">

</details>