### PR TITLE
이미지 편집 기능 중 회전 구현

### DIFF
--- a/MemorialHouse/MHPresentation/MHPresentation/Source/CustomAlbum/View/CustomAlbumViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/CustomAlbum/View/CustomAlbumViewController.swift
@@ -12,6 +12,7 @@ final class CustomAlbumViewController: UIViewController {
         flowLayout.minimumInteritemSpacing = 2
         flowLayout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        collectionView.backgroundColor = .clear
         
         return collectionView
     }()
@@ -36,11 +37,13 @@ final class CustomAlbumViewController: UIViewController {
         
         setup()
         configureConstraints()
+        configureNavagationBar()
         viewModel.action(.viewDidLoad)
     }
     
     // MARK: - Setup & Configure
     private func setup() {
+        view.backgroundColor = .baseBackground
         imagePicker.delegate = self
         albumCollectionView.delegate = self
         albumCollectionView.dataSource = self
@@ -53,6 +56,24 @@ final class CustomAlbumViewController: UIViewController {
     private func configureConstraints() {
         view.addSubview(albumCollectionView)
         albumCollectionView.fillSuperview()
+    }
+    
+    private func configureNavagationBar() {
+        navigationItem.title = "사진 선택"
+        navigationController?.navigationBar.titleTextAttributes = [
+            NSAttributedString.Key.font: UIFont.ownglyphBerry(size: 17),
+            NSAttributedString.Key.foregroundColor: UIColor.title]
+        let closeAction = UIAction { [weak self] _ in
+            guard let self else { return }
+            self.navigationController?.popViewController(animated: true)
+        }
+        let leftBarButton = UIBarButtonItem(title: "닫기", primaryAction: closeAction)
+        leftBarButton.setTitleTextAttributes(
+            [NSAttributedString.Key.font: UIFont.ownglyphBerry(size: 17),
+             NSAttributedString.Key.foregroundColor: UIColor.title],
+            for: .normal
+        )
+        navigationItem.leftBarButtonItem = leftBarButton
     }
     
     // MARK: - Open Camera

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/EditPhoto/EditPhotoViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/EditPhoto/EditPhotoViewController.swift
@@ -173,8 +173,9 @@ public final class EditPhotoViewController: UIViewController {
         let cropButtonAction = UIAction { _ in
             // TODO: - Crop Action
         }
-        let rotateButtonAction = UIAction { _ in
-            // TODO: - Rotate Action
+        let rotateButtonAction = UIAction { [weak self] _ in
+            let image = self?.photoView.image
+            self?.photoView.image = image?.rotate(radians: .pi / 2)
         }
         let drawButtonAction = UIAction { _ in
             // TODO: - Draw Action

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/EditPhoto/EditPhotoViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/EditPhoto/EditPhotoViewController.swift
@@ -28,8 +28,8 @@ public final class EditPhotoViewController: UIViewController {
     private let editButtonStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.spacing = 83
         stackView.alignment = .center
+        stackView.distribution = .equalCentering
         
         return stackView
     }()
@@ -124,11 +124,13 @@ public final class EditPhotoViewController: UIViewController {
     }
     
     private func configureConstraints() {
-        editButtonStackView.setCenterX(view: view)
-        editButtonStackView.setBottom(
-            anchor: view.safeAreaLayoutGuide.bottomAnchor,
-            constant: 16
+        editButtonStackView.setAnchor(
+            leading: view.leadingAnchor, constantLeading: 50,
+            bottom: view.safeAreaLayoutGuide.bottomAnchor,
+            trailing: view.trailingAnchor, constantTrailing: 50,
+            height: 80
         )
+        
         dividedLine1.setHorizontal(view: view)
         dividedLine1.setBottom(
             anchor: editButtonStackView.topAnchor,
@@ -137,7 +139,8 @@ public final class EditPhotoViewController: UIViewController {
         captionTextField.setAnchor(
             leading: view.leadingAnchor, constantLeading: 13,
             bottom: dividedLine1.topAnchor, constantBottom: 11,
-            trailing: view.trailingAnchor
+            trailing: view.trailingAnchor,
+            height: 30
         )
         dividedLine2.setHorizontal(view: view)
         dividedLine2.setBottom(
@@ -161,7 +164,7 @@ public final class EditPhotoViewController: UIViewController {
         dimmedView2.setAnchor(
             top: clearView.bottomAnchor,
             leading: view.leadingAnchor,
-            bottom: dividedLine2.topAnchor,
+            bottom: photoView.bottomAnchor,
             trailing: view.trailingAnchor
         )
     }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Extensions/UIImage+Rotate.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Extensions/UIImage+Rotate.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+extension UIImage {
+    func rotate(radians: Float) -> UIImage? {
+        /// 회전된 이미지의 새로운 이미지 크기 계산
+        var newSize = CGRect(
+            origin: CGPoint.zero,
+            size: self.size
+        ).applying(CGAffineTransform(rotationAngle: CGFloat(radians))).size
+        
+        /// Core Graphics가 반올림으로 인한 오차를 발생시키지 않도록 소수점 이하 버림
+        newSize.width = floor(newSize.width)
+        newSize.height = floor(newSize.height)
+        
+        /// 위에서 설정한 새로운 크기의 GraphicContext 생성
+        /// false: 배경을 투명하게 설정
+        /// self.scale: 원본 이미지의 해상도 유지
+        UIGraphicsBeginImageContextWithOptions(newSize, false, self.scale)
+        guard let context = UIGraphicsGetCurrentContext() else { return nil }
+        
+        /// Context의 원점을 이미지 중앙으로 이동
+        context.translateBy(x: newSize.width/2, y: newSize.height/2)
+        /// 중심점을 기준으로 이미지 회전
+        context.rotate(by: CGFloat(radians))
+        /// 회전된 context에 그림 그리기
+        /// 이때, 중앙을 기준으로 그리기 위해 x, y좌표를 넓이, 높이의 절반 음수 값을 넣어줌
+        self.draw(in: CGRect(
+                x: -self.size.width/2,
+                y: -self.size.height/2,
+                width: self.size.width,
+                height: self.size.height))
+    
+        /// 회전된 이미지를 새로운 UIImage로 생성 후 GraphicContext 종료
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return newImage
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #48 

<br>

## 📝 작업 내용
<!-- 본 PR에서 작업한 내용을 적어주세요 -->

- 이미지(UIImage) 회전 구현
- 커스텀 앨범의 네비게이션 바 설정

<br>

## 📸 스크린샷
<!-- 스크린샷 or 영상으로 PR을 설명해주세요 -->

<img width=350 src="https://github.com/user-attachments/assets/f23fea74-eae2-4016-bd79-c2dd50695c54">

<br>

## ⚽️ 트러블 슈팅
<!-- 개발 과정에서 발생한 문제를 노션에 작성하고, 그 내용을 여기에도 올려주세요 ! -->

### 이미지 회전에 애니메이션 넣기

일단 회전을 하는 방법에는 두 가지가 있었다.

- UIImageView 자체를 회전시키는 방법
- UIImage를 회전시키고 회전시킨 UIImage를 UIImageView에 넣는 방법

두 개의 방법 중 후자를 선택해서 구현하였다. 전자를 선택하지 않은 이유는 일단 지금 화면 계층이 dimmed view가 UIImageView 위에 올라가져있는 구성이기 때문에 UIImageView 자체가 돌아가버리면 그 위에 위치하고 있는 dimmed view도 같이 돌아가기 때문이다. dimmed view를 UIImageView 위에 올리지 않을 수도 있겠지만 나중에 이미지 편집이 끝난 후 중간에 투명하게 보이는 부분만 잘라서 사용하기 위해서는 clear view가 UIImageView 위에 존재해야 clipsToBounds를 사용해 원하는 이미지만 잘라낼 수 있지 않을까.. 라는 생각으로 일단 이렇게 진행했다.

추가로 전자의 방법으로 구현하는 것이 코드상 훨씬 쉽긴 했다.

```swift
self.photoView.transform = self.photoView.transform.rotated(by: .pi / 2)
```

위 한 줄만 있으면 되기 때문에... 하지만 이렇게 되면 처음 autolayout을 잡았을 때의 크기 그대로 돌아가 아래 이미지와 같이 사진이 화면에 꽉차게 보이지 않는 이슈가 있었다.

|회전 전|회전 후|
|:-:|:-:|
|<img width=350 src="https://github.com/user-attachments/assets/9b3818c2-7e8d-4608-86b1-b72801ecd45b">|<img width=350 src="https://github.com/user-attachments/assets/5a33a99b-9cff-4114-a5cb-b021fe7db9b8">|

따라서 후자의 방법으로 진행했다.

하지만 후자의 경우 내부의 이미지 크기를 바꾸는 일종의 랜더링을 하는 것이기 때문에 UIView.animate를 활용해 애니메이션을 넣는 것은 불가능했다.. 애니메이션을 넣고 싶었지만 아직 넣지 못했고 일단 애니메이션을 넣는 것은 후순위 작업이라 생각했기 때문에 아래와 같이 진행하게 되었다. 
