### PR TITLE
커스텀 앨범 동영상 버전 추가

### DIFF
--- a/MemorialHouse/MHApplication/MHApplication.xcodeproj/project.pbxproj
+++ b/MemorialHouse/MHApplication/MHApplication.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "기록소";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				INFOPLIST_KEY_NSCameraUsageDescription = "기록소는 카메라 권한을 필요로 합니다. 허용 안 함 시 일부 기능이 동작하지 않을 수 있습니다.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "기록소는 오디오 권한을 필요로 합니다. 허용 안 함 시 일부 기능이 동작하지 않을 수 있습니다.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "기록소는 사진 권한을 필요로 합니다. 허용 안 함 시 일부 기능이 동작하지 않을 수 있습니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -267,6 +268,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "기록소";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				INFOPLIST_KEY_NSCameraUsageDescription = "기록소는 카메라 권한을 필요로 합니다. 허용 안 함 시 일부 기능이 동작하지 않을 수 있습니다.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "기록소는 오디오 권한을 필요로 합니다. 허용 안 함 시 일부 기능이 동작하지 않을 수 있습니다.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "기록소는 사진 권한을 필요로 합니다. 허용 안 함 시 일부 기능이 동작하지 않을 수 있습니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;

--- a/MemorialHouse/MHApplication/MHApplication/Resource/Info.plist
+++ b/MemorialHouse/MHApplication/MHApplication/Resource/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/BookCreation/BookCreationViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/BookCreation/BookCreationViewController.swift
@@ -246,7 +246,7 @@ final class BookCreationViewController: UIViewController {
         // 사진선택 버튼
         let pictureSelectingAction = UIAction { [weak self] _ in
             let albumViewModel = CustomAlbumViewModel()
-            let customAlbumViewController = CustomAlbumViewController(viewModel: albumViewModel)
+            let customAlbumViewController = CustomAlbumViewController(viewModel: albumViewModel, mediaType: .image)
             self?.navigationController?.pushViewController(customAlbumViewController, animated: true)
         }
         imageSelectionButton.addAction(pictureSelectingAction, for: .touchUpInside)

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/CustomAlbum/ViewModel/CustomAlbumViewModel.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/CustomAlbum/ViewModel/CustomAlbumViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 
 final class CustomAlbumViewModel: ViewModelType {
     enum Input {
-        case viewDidLoad
+        case viewDidLoad(mediaType: PHAssetMediaType)
         case photoDidChanged(to: PHChange)
     }
     
@@ -20,8 +20,8 @@ final class CustomAlbumViewModel: ViewModelType {
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
         input.sink { [weak self] event in
             switch event {
-            case .viewDidLoad:
-                self?.fetchPhotoAssets()
+            case .viewDidLoad(let mediaType):
+                self?.fetchPhotoAssets(of: mediaType)
             case .photoDidChanged(let changeInstance):
                 self?.updatePhotoAssets(changeInstance)
             }
@@ -31,9 +31,10 @@ final class CustomAlbumViewModel: ViewModelType {
         return output.eraseToAnyPublisher()
     }
     
-    private func fetchPhotoAssets() {
+    private func fetchPhotoAssets(of mediaType: PHAssetMediaType) {
         let fetchOptions = PHFetchOptions()
-        fetchOptions.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue)
+        
+        fetchOptions.predicate = NSPredicate(format: "mediaType = %d", mediaType.rawValue)
         fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
         
         photoAsset = PHAsset.fetchAssets(with: fetchOptions)

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/CustomAlbum/ViewModel/LocalPhotoManager.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/CustomAlbum/ViewModel/LocalPhotoManager.swift
@@ -7,7 +7,7 @@ actor LocalPhotoManager {
     private let imageManager = PHImageManager()
     private let imageRequestOptions: PHImageRequestOptions = {
         let options = PHImageRequestOptions()
-        options.deliveryMode = .highQualityFormat
+        options.isSynchronous = true
         
         return options
     }()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #81 

<br>

## ⏰ 작업 시간
<!-- 해당 작업이 걸린 시간을 작성해주세요 -->

|예상 시간|실제 걸린 시간|
|:-:|:-:|
|1|1|

## 📝 작업 내용
<!-- 본 PR에서 작업한 내용을 적어주세요 -->

- 기존에 사진만 선택할 수 있었던 커스텀 앨범을 살짝 수정하여 동영상만 선택 및 촬영할 수 있는 커스텀 앨범 구현

<br>

## 📸 스크린샷
<!-- 스크린샷 or 영상으로 PR을 설명해주세요 -->

|동영상만 있는 앨범|동영상 촬영 화면|
|:-:|:-:|
|<img width=350 src="https://github.com/user-attachments/assets/89aa04b9-0a8c-4adf-b6b7-7218381a35a8">|<img width=350 src="https://github.com/user-attachments/assets/72223e3c-9897-43cd-88ba-b0eda15f5d17">|

<br>

## 📒 리뷰 노트

`CustomAlbumViewController`를 호출할 때, 두 번째 매개변수를 `.image`로 해주면 사진만 있는 앨범이 나오고, `.video`로 설정해주면 동영상만 있는 앨범이 나오게 됩니다. 추후 사용할 때 아래와 같이 사용하면 됩니다 !

```swift
// 사진만 있는 앨범
let customAlbumViewController = CustomAlbumViewController(viewModel: albumViewModel, mediaType: .image)

// 영상만 있는 앨범
let customAlbumViewController = CustomAlbumViewController(viewModel: albumViewModel, mediaType: .video)
```

추가로 아직 동영상에 대한 PHAsset만 호출해놓은 상황이라 편집뷰에서 해당 PHAsset을 활용하여 AVPlayer로 영상을 틀어주고, 저장하는 과정을 거쳐야할 것 같습니다 !

FileManager에 영상을 저장하지 않아도 PHAsset 만으로 영상을 재생시킬 수도 있기 때문에 책이 발행되면 그 때 영상을 저장시키는게 좋을 듯 하여 현재 PR에 올라간 만큼의 작업만 진행해둔 상태입니다 .ᐟ.ᐟ 