### PR TITLE
홈화면 책커버 Drag & Drop 구현

### DIFF
--- a/MemorialHouse/MHData/MHData/DTO/BookCoverDTO.swift
+++ b/MemorialHouse/MHData/MHData/DTO/BookCoverDTO.swift
@@ -3,14 +3,24 @@ import MHDomain
 
 public struct BookCoverDTO {
     let identifier: UUID
+    let order: Int
     let title: String
     let imageURL: String?
     let color: String
     let category: String?
     let favorite: Bool
     
-    public init(identifier: UUID, title: String, imageURL: String?, color: String, category: String?, favorite: Bool) {
+    public init(
+        identifier: UUID,
+        order: Int,
+        title: String,
+        imageURL: String?,
+        color: String,
+        category: String?,
+        favorite: Bool
+    ) {
         self.identifier = identifier
+        self.order = order
         self.title = title
         self.imageURL = imageURL
         self.color = color
@@ -23,6 +33,7 @@ public struct BookCoverDTO {
         
         return BookCover(
             identifier: self.identifier,
+            order: self.order,
             title: self.title,
             imageURL: self.imageURL,
             color: color,

--- a/MemorialHouse/MHData/MHData/LocalStorage/CoreData/CoreDataBookCoverStorage.swift
+++ b/MemorialHouse/MHData/MHData/LocalStorage/CoreData/CoreDataBookCoverStorage.swift
@@ -122,6 +122,7 @@ extension CoreDataBookCoverStorage {
         
         return BookCoverDTO(
             identifier: identifier,
+            order: Int(bookCover.order),
             title: title,
             imageURL: bookCover.imageURL,
             color: color,

--- a/MemorialHouse/MHData/MHData/LocalStorage/CoreData/MemorialHouseModel.xcdatamodeld/MemorialHouseModel.xcdatamodel/contents
+++ b/MemorialHouse/MHData/MHData/LocalStorage/CoreData/MemorialHouseModel.xcdatamodeld/MemorialHouseModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="24B2082" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="24B2091" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="BookCategoryEntity" representedClassName="BookCategoryEntity" syncable="YES" codeGenerationType="class">
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -10,6 +10,7 @@
         <attribute name="favorite" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="identifier" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="imageURL" optional="YES" attributeType="String"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
     </entity>
     <entity name="BookEntity" representedClassName="BookEntity" syncable="YES" codeGenerationType="class">

--- a/MemorialHouse/MHData/MHData/Repository/LocalBookCoverRepository.swift
+++ b/MemorialHouse/MHData/MHData/Repository/LocalBookCoverRepository.swift
@@ -12,6 +12,7 @@ public struct LocalBookCoverRepository: BookCoverRepository {
     public func create(bookCover: BookCover) async {
         let bookCoverDTO = BookCoverDTO(
             identifier: bookCover.identifier,
+            order: bookCover.order,
             title: bookCover.title,
             imageURL: bookCover.imageURL,
             color: bookCover.color.rawValue,
@@ -51,6 +52,7 @@ public struct LocalBookCoverRepository: BookCoverRepository {
     public func update(id: UUID, bookCover: BookCover) async {
         let bookCoverDTO = BookCoverDTO(
             identifier: bookCover.identifier,
+            order: bookCover.order,
             title: bookCover.title,
             imageURL: bookCover.imageURL,
             color: bookCover.color.rawValue,

--- a/MemorialHouse/MHData/MHDataTests/CoreDataBookCoverStorageTests.swift
+++ b/MemorialHouse/MHData/MHDataTests/CoreDataBookCoverStorageTests.swift
@@ -10,6 +10,7 @@ struct CoreDataBookCoverStorageTests {
     private static let bookCovers = [
         BookCoverDTO(
             identifier: UUID(),
+            order: 1,
             title: "test1",
             imageURL: nil,
             color: "pink",
@@ -17,6 +18,7 @@ struct CoreDataBookCoverStorageTests {
             favorite: true),
         BookCoverDTO(
             identifier: UUID(),
+            order: 2,
             title: "test2",
             imageURL: nil,
             color: "blue",
@@ -24,6 +26,7 @@ struct CoreDataBookCoverStorageTests {
             favorite: false),
         BookCoverDTO(
             identifier: UUID(),
+            order: 3,
             title: "test3",
             imageURL: nil,
             color: "beige",
@@ -41,6 +44,7 @@ struct CoreDataBookCoverStorageTests {
         // Arrange
         let newBookCover = BookCoverDTO(
             identifier: UUID(),
+            order: 4,
             title: "test4",
             imageURL: nil,
             color: "green",
@@ -83,6 +87,7 @@ struct CoreDataBookCoverStorageTests {
         let oldBookCover = CoreDataBookCoverStorageTests.bookCovers[0]
         let newBookCover = BookCoverDTO(
             identifier: oldBookCover.identifier,
+            order: 4,
             title: "test4",
             imageURL: nil,
             color: "green",

--- a/MemorialHouse/MHData/MHDataTests/MHFileManagerTests.swift
+++ b/MemorialHouse/MHData/MHDataTests/MHFileManagerTests.swift
@@ -30,6 +30,7 @@ import Testing
             #expect(false, "\(#function) 실패함: \(error)")
         }
     }
+    
     @Test func test파일읽기_성공() async {
         // Arrange
         let path = testDirectory
@@ -46,6 +47,7 @@ import Testing
             #expect(false, "\(#function) 실패함: \(error)")
         }
     }
+    
     @Test func test없는_파일읽기_실패() async {
         // Arrange
         let path = testDirectory
@@ -61,6 +63,7 @@ import Testing
             #expect(error == .fileNotExists)
         }
     }
+    
     @Test func test파일삭제_성공() async {
         // Arrange
         let path = testDirectory
@@ -79,6 +82,7 @@ import Testing
             #expect(false, "\(#function) 실패함: \(error)")
         }
     }
+    
     @Test func test없는_파일삭제_실패() async {
         // Arrange
         let path = testDirectory
@@ -94,6 +98,7 @@ import Testing
             #expect(error == .fileDeletionFailure)
         }
     }
+    
     @Test func test파일이동_성공() async {
         // Arrange
         let path = testDirectory
@@ -114,7 +119,6 @@ import Testing
         }
     }
 
-    
     deinit {
         // 테스트 디렉토리와 관련된 파일 정리
         let directoryURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!

--- a/MemorialHouse/MHDomain/MHDomain/Entity/BookCover.swift
+++ b/MemorialHouse/MHDomain/MHDomain/Entity/BookCover.swift
@@ -2,6 +2,7 @@ import MHFoundation
 
 public struct BookCover: Equatable, Sendable {
     public let identifier: UUID
+    public let order: Int
     public let title: String
     public let imageURL: String?
     public let color: BookColor
@@ -10,6 +11,7 @@ public struct BookCover: Equatable, Sendable {
     
     public init(
         identifier: UUID = .init(),
+        order: Int,
         title: String,
         imageURL: String?,
         color: BookColor,
@@ -17,6 +19,7 @@ public struct BookCover: Equatable, Sendable {
         favorite: Bool = false
     ) {
         self.identifier = identifier
+        self.order = order
         self.title = title
         self.imageURL = imageURL
         self.color = color

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewController.swift
@@ -282,7 +282,10 @@ extension HomeViewController: UICollectionViewDataSource {
 }
 
 extension HomeViewController: BookCategoryViewControllerDelegate {
-    func categoryViewController(_ categoryViewController: BookCategoryViewController, didSelectCategory category: String) {
+    func categoryViewController(
+        _ categoryViewController: BookCategoryViewController,
+        didSelectCategory category: String
+    ) {
         currentCategory = category
         input.send(.selectedCategory(category: category))
     }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewController.swift
@@ -320,17 +320,22 @@ extension HomeViewController: UICollectionViewDropDelegate {
             destinationIndexPath = IndexPath(item: row - 1, section: 0)
         }
         
-        guard coordinator.proposal.operation == .move else { return }
-        move(coordinator: coordinator, destinationIndexPath: destinationIndexPath, collectionView: collectionView)
+        moveItems(
+            coordinator: coordinator,
+            destinationIndexPath: destinationIndexPath,
+            collectionView: collectionView
+        )
     }
     
-    private func move(
+    private func moveItems(
         coordinator: UICollectionViewDropCoordinator,
         destinationIndexPath: IndexPath,
         collectionView: UICollectionView
     ) {
-        guard let item = coordinator.items.first,
-              let sourceIndexPath = item.sourceIndexPath
+        guard
+            coordinator.proposal.operation == .move,
+            let item = coordinator.items.first,
+            let sourceIndexPath = item.sourceIndexPath
         else { return }
         
         collectionView.performBatchUpdates { [weak self] in
@@ -344,8 +349,6 @@ extension HomeViewController: UICollectionViewDropDelegate {
             
             collectionView.deleteItems(at: [sourceIndexPath])
             collectionView.insertItems(at: [destinationIndexPath])
-        } completion: { _ in
-            coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
         }
     }
 }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewController.swift
@@ -101,6 +101,8 @@ public final class HomeViewController: UIViewController {
                 self.collectionView.reloadData()
             case .fetchedFailure(let errorMessage):
                 self.handleError(with: errorMessage)
+            case .dragAndDropFinished:
+                self.collectionView.reloadData()
             }
         }.store(in: &cancellables)
     }
@@ -333,9 +335,12 @@ extension HomeViewController: UICollectionViewDropDelegate {
         
         collectionView.performBatchUpdates { [weak self] in
             guard let self else { return }
-            let sourceItem = self.viewModel.bookCovers[sourceIndexPath.item]
-            self.viewModel.bookCovers.remove(at: sourceIndexPath.item)
-            self.viewModel.bookCovers.insert(sourceItem, at: destinationIndexPath.item)
+            input.send(
+                .dragAndDropBookCover(
+                    currentIndex: sourceIndexPath.item,
+                    destinationIndex: destinationIndexPath.item
+                )
+            )
             
             collectionView.deleteItems(at: [sourceIndexPath])
             collectionView.insertItems(at: [destinationIndexPath])

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewController.swift
@@ -97,12 +97,10 @@ public final class HomeViewController: UIViewController {
             switch event {
             case .fetchedMemorialHouseAndCategory:
                 self.updateMemorialHouse()
-            case .filteredBooks:
+            case .filteredBooks, .dragAndDropFinished:
                 self.collectionView.reloadData()
             case .fetchedFailure(let errorMessage):
                 self.handleError(with: errorMessage)
-            case .dragAndDropFinished:
-                self.collectionView.reloadData()
             }
         }.store(in: &cancellables)
     }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewModel.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewModel.swift
@@ -18,7 +18,7 @@ public final class HomeViewModel: ViewModelType {
     private let fetchMemorialHouseUseCase: FetchMemorialHouseUseCase
     private var cancellables = Set<AnyCancellable>()
     private(set) var houseName = ""
-    private(set) var bookCovers = [BookCover]()
+    var bookCovers = [BookCover]()
     private(set) var currentBookCovers = [BookCover]()
     
     public init(fetchMemorialHouseUseCase: FetchMemorialHouseUseCase) {

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewModel.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Home/HomeViewModel.swift
@@ -6,19 +6,21 @@ public final class HomeViewModel: ViewModelType {
     public enum Input {
         case viewDidLoad
         case selectedCategory(category: String)
+        case dragAndDropBookCover(currentIndex: Int, destinationIndex: Int)
     }
     
     public enum Output {
         case fetchedMemorialHouseAndCategory
         case filteredBooks
         case fetchedFailure(String)
+        case dragAndDropFinished
     }
     
     private let output = PassthroughSubject<Output, Never>()
     private let fetchMemorialHouseUseCase: FetchMemorialHouseUseCase
     private var cancellables = Set<AnyCancellable>()
     private(set) var houseName = ""
-    var bookCovers = [BookCover]()
+    private(set) var bookCovers = [BookCover]()
     private(set) var currentBookCovers = [BookCover]()
     
     public init(fetchMemorialHouseUseCase: FetchMemorialHouseUseCase) {
@@ -41,6 +43,8 @@ public final class HomeViewModel: ViewModelType {
                 }
             case .selectedCategory(let category):
                 self?.filterBooks(by: category)
+            case .dragAndDropBookCover(let currentIndex, let destinationIndex):
+                self?.dragAndDropBookCover(from: currentIndex, to: destinationIndex)
             }
         }.store(in: &cancellables)
         
@@ -65,5 +69,15 @@ public final class HomeViewModel: ViewModelType {
         }
 
         output.send(.filteredBooks)
+    }
+    
+    private func dragAndDropBookCover(from currentIndex: Int, to destinationIndex: Int) {
+        let currentBookCover = currentBookCovers[currentIndex]
+        let targetBookCover = currentBookCovers[destinationIndex]
+        bookCovers.remove(at: currentBookCover.order)
+        bookCovers.insert(currentBookCover, at: targetBookCover.order)
+        currentBookCovers.remove(at: currentIndex)
+        currentBookCovers.insert(currentBookCover, at: destinationIndex)
+        output.send(.dragAndDropFinished)
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #100 

<br>

## ⏰ 작업 시간
<!-- 해당 작업이 걸린 시간을 작성해주세요 -->

|예상 시간|실제 걸린 시간|
|:-:|:-:|
|3|3|

## 📝 작업 내용
<!-- 본 PR에서 작업한 내용을 적어주세요 -->
- 홈화면 책커버 Drag & Drop 구현
- BookCover 모델 3개에 order: Int 프로퍼티 추가

<br>

## 📸 스크린샷
<!-- 스크린샷 or 영상으로 PR을 설명해주세요 -->
|iPhone SE|iPhone 16 Pro|
|---|---|
|![드래그앤드랍-SE](https://github.com/user-attachments/assets/5d83c6d9-7f2b-4180-aa5a-804bfd65a51f)|![드래그앤드랍 구현](https://github.com/user-attachments/assets/da23ddc7-dd85-4bf9-acb6-c2406a234acb)|

<img width="570" alt="image" src="https://github.com/user-attachments/assets/e75f96ac-6638-4857-b622-ecfb612397e4">

<br>

## 📒 리뷰 노트
<!-- 본 PR과 관련하여 특이사항이 있다면 알려주세요 -->

## 드래그 앤 드랍 개요

우리는 아래의 두 델리게이트 프로토콜을 사용할 것이고,

델리게이트에서 총 3개의 메소드를 사용하여 드래그 앤 드랍을 구현할 거다.

- UICollectionView**Drag**Delegate
- UICollectionView**Drop**Delegate

### 시작: **`collectionView(_:itemsForBeginning:at:)`**

먼저 **Drag** 델리게이트의 메소드이다.

처음 드래그가 시작될 때 호출되는 메소드로 말 그대로 “드래그”를 시작할 때 동작한다.

### **중간: `collectionView(_:dropSessionDidUpdate:withDestinationIndexPath:)`**

**Drop** 델리게이트의 메소드이다.

드래그 동작 중에 호출되는 메소드로 드래그가 잘 되고 있는지 등에 대한 유효성 검사?를 할 수 있다.

### **끝: `collectionView(_:performDropWith:**)`

**Drop** 델리게이트의 메소드이다.

해당 메소드는 Drag를 마치고 Drop이 발생했을 때 호출된다.

---

## 우리 프로젝트에 적용해보기

이 책 4권을 드래그 앤 드랍으로 이리저리 움직여서 위치를 옮겨봅시다.

<img width="166" alt="image" src="https://github.com/user-attachments/assets/a5495f22-f59b-492e-bdad-acd740449351">


### 1. 드래그 준비

```swift
extension HomeViewController: UICollectionViewDragDelegate {
    public func collectionView(
        _ collectionView: UICollectionView,
        itemsForBeginning session: any UIDragSession,
        at indexPath: IndexPath
    ) -> [UIDragItem] {
        let dragItem = UIDragItem(itemProvider: NSItemProvider())
        return [dragItem]
    }
}
```

Drag 델리게이트를 채택하고 `itemsForBeginning`  메소드를 구현한다.

UIDragItem을 배열에 담아서 보내주는데, 이는 다른 앱과 상호작용할 때도 쓰일 수 있다고 함..!

그래서 아래처럼 사용 가능하다. 아마 사진 앱도 얘를 사용한 게 아닐까 ?

![UIDragItem](https://github.com/user-attachments/assets/536fd227-06ca-4935-95d7-528ffb56bfe1)

### 2. 드래그 중

```swift
extension HomeViewController: UICollectionViewDropDelegate {
    public func collectionView(
        _ collectionView: UICollectionView,
        dropSessionDidUpdate session: UIDropSession,
        withDestinationIndexPath destinationIndexPath: IndexPath?
    ) -> UICollectionViewDropProposal {
        guard collectionView.hasActiveDrag else { return UICollectionViewDropProposal(operation: .forbidden) }
        return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
    }
```

드래그 중에는 유효성 검증을 한다.

collectionView.hasActiveDrag을 통해서 컬렉션 뷰가 드래그 중이면 `operation` 을 move로 주고,

그렇지 않으면 forbidden으로 준다. forbidden으로 처리되면 드래그를 하고 드랍을 했을 때 아무일도 발생하지 않음

이외에도 Cancel, copy가 있다

### 3. 드래그 끝, 드랍 시점

```swift
public func collectionView(
    _ collectionView: UICollectionView,
    performDropWith coordinator: UICollectionViewDropCoordinator
) {
    var destinationIndexPath: IndexPath
    if let indexPath = coordinator.destinationIndexPath {
        destinationIndexPath = indexPath
    } else {
        let row = collectionView.numberOfItems(inSection: 0)
        destinationIndexPath = IndexPath(item: row - 1, section: 0)
    }
    
    moveItems(
        coordinator: coordinator,
        destinationIndexPath: destinationIndexPath,
        collectionView: collectionView
    )
}

private func moveItems(
    coordinator: UICollectionViewDropCoordinator,
    destinationIndexPath: IndexPath,
    collectionView: UICollectionView
) {
    guard
        coordinator.proposal.operation == .move,
        let item = coordinator.items.first,
        let sourceIndexPath = item.sourceIndexPath
    else { return }
    
    collectionView.performBatchUpdates { [weak self] in
        guard let self else { return }
        input.send(
            .dragAndDropBookCover(
                currentIndex: sourceIndexPath.item,
                destinationIndex: destinationIndexPath.item
            )
        )
        
        collectionView.deleteItems(at: [sourceIndexPath])
        collectionView.insertItems(at: [destinationIndexPath])
    }
}
```

드래그가 끝나면 내가 놓은 셀의 위치 `destinationIndexPath` 를 받아서 해당 위치로 옮겨 주면 된다.

이를 구현하기 위해서 remove로 현재 자신의 위치를 제거한다. 그러면 이때 자신을 기준으로 뒤에있던 요소들은 한 칸씩 앞으로 땡겨질 거고,

destinationIndexPath을 통해서 insert를 해주면 원하는 대로 결과를 받을 수 있다.

나는 이때, viewModel에게 input을 보내어 처리를 하게 하였고, collectionView의 Item 또한 삭제와 삽입을 해주어 처리하였다.

<br>

## ⚽️ 트러블 슈팅
<!-- 개발 과정에서 발생한 문제를 노션에 작성하고, 그 내용을 여기에도 올려주세요 ! -->
## 드래그 앤 드랍 시 카테고리가 변경되어도 일관성 유지하기

지난 편에서 CollectionView Drag Drop 델리게이트를 통해서 드래그 앤 드랍을 구현했었다.

근데 우리는 책 커버를 한 번에 모아볼 수 있는 “전체”도 있고, 특정 카테고리에 대한 책 커버만 보여줄 수도 있다.

이것에 대한 일관성 처리를 어떻게 할 지 알아보자.

---
## 시나리오

`가족`, `친구` 두 카테고리와 책들이 다음과 같이 있다고 가정해보겠다.

<img width="643" alt="image" src="https://github.com/user-attachments/assets/59dee003-1bb9-4263-9a65-d49307a8055a">


이 상황에서 “가족” 카테고리에서 책1을 책3으로 옮겼다고 하자.

나는 그러면 “전체”에서 볼 때도 책1은 책3 뒤에 있어야 한다고 생각한다.

<img width="663" alt="image" src="https://github.com/user-attachments/assets/76a2025f-4e0b-474e-aa88-e3df97268793">

위처럼 말이다.

또한, 반대로 “전체”에서 책1을 책3으로 옮겨도,

“가족” 카테고리에서 보면 책1은 책3 뒤에 있어야 한다고 생각한다.

나는 위 두 상황에 대한 일관성을 유지해주기 위해서 BookCover 모델들에게 order라는 프로퍼티를 추가했다.

위 사진에서 빨간색 숫자가 order 값이다..!

### HomeViewModel 처리

HomeViewModel에는 아래의 프로퍼티가 있다.

**`private**(**set**) **var** bookCovers = [BookCover]()`

**`private**(**set**) **var** currentBookCovers = [BookCover]()`

currentBookCovers는 현재 화면을 그리기 위해 필요한 프로퍼티이다.

```swift
private func dragAndDropBookCover(from currentIndex: Int, to destinationIndex: Int) {
    let currentBookCover = currentBookCovers[currentIndex]
    let targetBookCover = currentBookCovers[destinationIndex]
    bookCovers.remove(at: currentBookCover.order)
    bookCovers.insert(currentBookCover, at: targetBookCover.order)
    currentBookCovers.remove(at: currentBookCover.order)
    currentBookCovers.insert(currentBookCover, at: targetBookCover.order)
}
```

뷰모델이 input을 받으면 위 메소드로 인해 위의 두 개의 프로퍼티가 갱신된다.

그런데, 다음과 같이 인덱스 에러가 발생했음..!

전체 카테고리에서 드래그 앤 드랍이 발생하면 아무 문제가 없는데,

특정 카테고리에서는 인덱스 접근 문제가 생김..

열심히 끄적끄적..

<img width="615" alt="image" src="https://github.com/user-attachments/assets/b70de680-cd70-4e47-9d4d-12db8d725304">

```swift
private func dragAndDropBookCover(from currentIndex: Int, to destinationIndex: Int) {
    let currentBookCover = currentBookCovers[currentIndex]
    let targetBookCover = currentBookCovers[destinationIndex]
    bookCovers.remove(at: currentBookCover.order)
    bookCovers.insert(currentBookCover, at: targetBookCover.order)
    currentBookCovers.remove(at: currentIndex)
    currentBookCovers.insert(currentBookCover, at: destinationIndex)
    output.send(.dragAndDropFinished)
}
```

현재 카테고리를 나타내는 currentBookCovers에서는 컬렉션 뷰의 인덱스, 즉 파라미터로 넘어온 것들로만 삽입 삭제를 하면 되고

전체 bookCovers에서는 order로 연산을 해주면 일관성을 유지할 수 있었다 !!!

근데 코어데이터까지 이거 되는지는 NSSortDescriptor 써봐야 알아서 더 살펴봐야함..