### PR TITLE
책 내용 수정시 크래시나는 것 수정

### DIFF
--- a/MemorialHouse/MHPresentation/MHPresentation/Source/EditBook/View/MediaAttachment.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/EditBook/View/MediaAttachment.swift
@@ -1,5 +1,4 @@
 import UIKit
-import AVKit
 import MHDomain
 
 protocol MediaAttachmentDataSource: AnyObject {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #117 
<br>

## ⏰ 작업 시간
<!-- 해당 작업이 걸린 시간을 작성해주세요 -->

|예상 시간|실제 걸린 시간|
|:-:|:-:|
|2|4|

## 📝 작업 내용
<!-- 본 PR에서 작업한 내용을 적어주세요 -->
사진을 넣은 상태에서
사진 추가버튼 + 엔터를 같이 누르면 크래시가 났다.
이것을 수정했습니다.
<br>

## 📒 리뷰 노트
<!-- 본 PR과 관련하여 특이사항이 있다면 알려주세요 -->
로직이 좀 더럽습니다...
사진 앞에서 치면 자동으로 개행이 되는 것과 짬뽕이 되어서 에러가 좀 났는데요
Attachment를 추가하는 부분이 사이즈가 넘어가면 삭제되게 하는 게 에러가 많이 났나봐요...
그래서 그냥 attachment를 추가하는 함수를 별도로 만들어서 사이즈 검사를 먼저한다음에 안넣는 방식으로 바꿨습니다.
<br>
