### PR TITLE
Swift Concurrency 리펙토링

### DIFF
--- a/MemorialHouse/MHApplication/MHApplication/Source/App/SceneDelegate.swift
+++ b/MemorialHouse/MHApplication/MHApplication/Source/App/SceneDelegate.swift
@@ -15,17 +15,19 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        registerDependency()
-        
-        let initialViewController = createInitialViewController()
-        let navigationController = UINavigationController(rootViewController: initialViewController)
-        window?.rootViewController = navigationController
-        window?.makeKeyAndVisible()
+        Task {
+            await registerDependency()
+            
+            let initialViewController = await createInitialViewController()
+            let navigationController = UINavigationController(rootViewController: initialViewController)
+            window?.rootViewController = navigationController
+            window?.makeKeyAndVisible()
+        }
     }
     
     // MARK: - 시작화면 설정
-    private func createInitialViewController() -> UIViewController {
-        return isUserRegistered()
+    private func createInitialViewController() async -> UIViewController {
+        return await isUserRegistered()
         ? createHomeViewController()
         : OnboardingViewController()
     }
@@ -34,9 +36,9 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         UserDefaults.standard.object(forKey: Constant.houseNameUserDefaultKey) != nil
     }
     
-    private func createHomeViewController() -> UIViewController {
+    private func createHomeViewController() async -> UIViewController {
         do {
-            let homeViewModelFactory = try DIContainer.shared.resolve(HomeViewModelFactory.self)
+            let homeViewModelFactory = try await DIContainer.shared.resolve(HomeViewModelFactory.self)
             let homeViewModel = homeViewModelFactory.make()
             return HomeViewController(viewModel: homeViewModel)
         } catch {
@@ -46,12 +48,12 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     // MARK: - DIContainer Dependency Injection
-    private func registerDependency() {
+    private func registerDependency() async {
         do {
-            try registerStorageDepedency()
-            try registerRepositoryDependency()
-            try registerUseCaseDependency()
-            try registerViewModelFactoryDependency()
+            try await registerStorageDepedency()
+            try await registerRepositoryDependency()
+            try await registerUseCaseDependency()
+            try await registerViewModelFactoryDependency()
         } catch let error as MHCoreError {
             MHLogger.error(error.description + #function)
         } catch {
@@ -59,187 +61,187 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
     
-    private func registerStorageDepedency() throws {
-        DIContainer.shared.register(CoreDataStorage.self, object: CoreDataStorage())
+    private func registerStorageDepedency() async throws {
+        await DIContainer.shared.register(CoreDataStorage.self, object: CoreDataStorage())
         
-        let coreDataStorage = try DIContainer.shared.resolve(CoreDataStorage.self)
-        DIContainer.shared.register(
+        let coreDataStorage = try await DIContainer.shared.resolve(CoreDataStorage.self)
+        await DIContainer.shared.register(
             CoreDataBookCoverStorage.self,
             object: CoreDataBookCoverStorage(coreDataStorage: coreDataStorage)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             CoreDataBookStorage.self,
             object: CoreDataBookStorage(coreDataStorage: coreDataStorage)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             BookCategoryStorage.self,
             object: CoreDataBookCategoryStorage(coreDataStorage: coreDataStorage)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             BookCoverStorage.self,
             object: CoreDataBookCoverStorage(coreDataStorage: coreDataStorage)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             BookStorage.self,
             object: CoreDataBookStorage(coreDataStorage: coreDataStorage)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             MemorialHouseNameStorage.self,
             object: UserDefaultsMemorialHouseNameStorage()
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             MHFileManager.self,
             object: MHFileManager(directoryType: .documentDirectory)
         )
     }
     
-    private func registerRepositoryDependency() throws {
-        let memorialHouseNameStorage = try DIContainer.shared.resolve(MemorialHouseNameStorage.self)
-        DIContainer.shared.register(
+    private func registerRepositoryDependency() async throws {
+        let memorialHouseNameStorage = try await DIContainer.shared.resolve(MemorialHouseNameStorage.self)
+        await DIContainer.shared.register(
             MemorialHouseNameRepository.self,
             object: LocalMemorialHouseNameRepository(storage: memorialHouseNameStorage)
         )
         
-        let bookCategoryStorage = try DIContainer.shared.resolve(BookCategoryStorage.self)
-        DIContainer.shared.register(
+        let bookCategoryStorage = try await DIContainer.shared.resolve(BookCategoryStorage.self)
+        await DIContainer.shared.register(
             BookCategoryRepository.self,
             object: LocalBookCategoryRepository(storage: bookCategoryStorage)
         )
-        let bookCoverStorage = try DIContainer.shared.resolve(BookCoverStorage.self)
-        DIContainer.shared.register(
+        let bookCoverStorage = try await DIContainer.shared.resolve(BookCoverStorage.self)
+        await DIContainer.shared.register(
             BookCoverRepository.self,
             object: LocalBookCoverRepository(storage: bookCoverStorage)
         )
-        let bookStorage = try DIContainer.shared.resolve(BookStorage.self)
-        DIContainer.shared.register(
+        let bookStorage = try await DIContainer.shared.resolve(BookStorage.self)
+        await DIContainer.shared.register(
             BookRepository.self,
             object: LocalBookRepository(storage: bookStorage)
         )
-        let fileManager = try DIContainer.shared.resolve(MHFileManager.self)
-        DIContainer.shared.register(
+        let fileManager = try await DIContainer.shared.resolve(MHFileManager.self)
+        await DIContainer.shared.register(
             MediaRepository.self,
             object: LocalMediaRepository(storage: fileManager)
         )
     }
     
-    private func registerUseCaseDependency() throws {
+    private func registerUseCaseDependency() async throws {
         // MARK: MemorialHouse UseCase
-        let memorialHouseNameRepository = try DIContainer.shared.resolve(MemorialHouseNameRepository.self)
-        DIContainer.shared.register(
+        let memorialHouseNameRepository = try await DIContainer.shared.resolve(MemorialHouseNameRepository.self)
+        await DIContainer.shared.register(
             CreateMemorialHouseNameUseCase.self,
             object: DefaultCreateMemorialHouseNameUseCase(repository: memorialHouseNameRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             FetchMemorialHouseNameUseCase.self,
             object: DefaultFetchMemorialHouseNameUseCase(repository: memorialHouseNameRepository)
         )
         
         // MARK: Category UseCase
-        let bookCategoryRepository = try DIContainer.shared.resolve(BookCategoryRepository.self)
-        DIContainer.shared.register(
+        let bookCategoryRepository = try await DIContainer.shared.resolve(BookCategoryRepository.self)
+        await DIContainer.shared.register(
             CreateBookCategoryUseCase.self,
             object: DefaultCreateBookCategoryUseCase(repository: bookCategoryRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             FetchBookCategoriesUseCase.self,
             object: DefaultFetchBookCategoriesUseCase(repository: bookCategoryRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             UpdateBookCategoryUseCase.self,
             object: DefaultUpdateBookCategoryUseCase(repository: bookCategoryRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             DeleteBookCategoryUseCase.self,
             object: DefaultDeleteBookCategoryUseCase(repository: bookCategoryRepository)
         )
         
         // MARK: - Book UseCase
-        let bookRepository = try DIContainer.shared.resolve(BookRepository.self)
-        let mediaRepository = try DIContainer.shared.resolve(MediaRepository.self)
-        DIContainer.shared.register(
+        let bookRepository = try await DIContainer.shared.resolve(BookRepository.self)
+        let mediaRepository = try await DIContainer.shared.resolve(MediaRepository.self)
+        await DIContainer.shared.register(
             CreateBookUseCase.self,
             object: DefaultCreateBookUseCase(repository: bookRepository,
                                              mediaRepository: mediaRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             FetchBookUseCase.self,
             object: DefaultFetchBookUseCase(repository: bookRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             UpdateBookUseCase.self,
             object: DefaultUpdateBookUseCase(repository: bookRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             DeleteBookUseCase.self,
             object: DefaultDeleteBookUseCase(repository: bookRepository)
         )
         
         // MARK: - BookCover UseCase
-        let bookCoverRepository = try DIContainer.shared.resolve(BookCoverRepository.self)
-        DIContainer.shared.register(
+        let bookCoverRepository = try await DIContainer.shared.resolve(BookCoverRepository.self)
+        await DIContainer.shared.register(
             CreateBookCoverUseCase.self,
             object: DefaultCreateBookCoverUseCase(repository: bookCoverRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             FetchAllBookCoverUseCase.self,
             object: DefaultFetchAllBookCoverUseCase(repository: bookCoverRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             FetchBookCoverUseCase.self,
             object: DefaultFetchBookCoverUseCase(repository: bookCoverRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             UpdateBookCoverUseCase.self,
             object: DefaultUpdateBookCoverUseCase(repository: bookCoverRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             DeleteBookCoverUseCase.self,
             object: DefaultDeleteBookCoverUseCase(repository: bookCoverRepository)
         )
         
         // MARK: - EditBook UseCase
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             PersistentlyStoreMediaUseCase.self,
             object: DefaultPersistentlyStoreMediaUseCase(repository: mediaRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             CreateMediaUseCase.self,
             object: DefaultCreateMediaUseCase(repository: mediaRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             FetchMediaUseCase.self,
             object: DefaultFetchMediaUseCase(repository: mediaRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             DeleteMediaUseCase.self,
             object: DefaultDeleteMediaUseCase(repository: mediaRepository)
         )
         
         // MARK: - TemporaryStoreMedia UseCase
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             TemporaryStoreMediaUseCase.self,
             object: DefaultTemporaryStoreMediaUseCase(repository: mediaRepository)
         )
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             DeleteTemporaryMediaUseCase.self,
             object: DefaultDeleteTemporaryMediaUseCase(repository: mediaRepository)
         )
     }
     
-    private func registerViewModelFactoryDependency() throws {
+    private func registerViewModelFactoryDependency() async throws {
         // MARK: Register ViewModel
-        let createMemorialHouseNameUseCase = try DIContainer.shared.resolve(CreateMemorialHouseNameUseCase.self)
-        DIContainer.shared.register(
+        let createMemorialHouseNameUseCase = try await DIContainer.shared.resolve(CreateMemorialHouseNameUseCase.self)
+        await DIContainer.shared.register(
             RegisterViewModelFactory.self,
             object: RegisterViewModelFactory(createMemorialHouseNameUseCase: createMemorialHouseNameUseCase)
         )
         
         // MARK: Home ViewModel
-        let fetchMemorialHouseNameUseCase = try DIContainer.shared.resolve(FetchMemorialHouseNameUseCase.self)
-        let fetchAllBookCoverUseCase = try DIContainer.shared.resolve(FetchAllBookCoverUseCase.self)
-        let updateBookCoverUseCase = try DIContainer.shared.resolve(UpdateBookCoverUseCase.self)
-        let deleteBookCoverUseCase = try DIContainer.shared.resolve(DeleteBookCoverUseCase.self)
-        DIContainer.shared.register(
+        let fetchMemorialHouseNameUseCase = try await DIContainer.shared.resolve(FetchMemorialHouseNameUseCase.self)
+        let fetchAllBookCoverUseCase = try await DIContainer.shared.resolve(FetchAllBookCoverUseCase.self)
+        let updateBookCoverUseCase = try await DIContainer.shared.resolve(UpdateBookCoverUseCase.self)
+        let deleteBookCoverUseCase = try await DIContainer.shared.resolve(DeleteBookCoverUseCase.self)
+        await DIContainer.shared.register(
             HomeViewModelFactory.self,
             object: HomeViewModelFactory(
                 fetchMemorialHouseNameUseCase: fetchMemorialHouseNameUseCase,
@@ -250,11 +252,11 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
         
         // MARK: Category ViewModel
-        let createBookCategoryUseCase = try DIContainer.shared.resolve(CreateBookCategoryUseCase.self)
-        let fetchBookCategoriesUseCase = try DIContainer.shared.resolve(FetchBookCategoriesUseCase.self)
-        let updateBookCategoryUseCase = try DIContainer.shared.resolve(UpdateBookCategoryUseCase.self)
-        let deleteBookCategoryUseCase = try DIContainer.shared.resolve(DeleteBookCategoryUseCase.self)
-        DIContainer.shared.register(
+        let createBookCategoryUseCase = try await DIContainer.shared.resolve(CreateBookCategoryUseCase.self)
+        let fetchBookCategoriesUseCase = try await DIContainer.shared.resolve(FetchBookCategoriesUseCase.self)
+        let updateBookCategoryUseCase = try await DIContainer.shared.resolve(UpdateBookCategoryUseCase.self)
+        let deleteBookCategoryUseCase = try await DIContainer.shared.resolve(DeleteBookCategoryUseCase.self)
+        await DIContainer.shared.register(
             BookCategoryViewModelFactory.self,
             object: BookCategoryViewModelFactory(
                 createBookCategoryUseCase: createBookCategoryUseCase,
@@ -265,10 +267,10 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
         
         // MARK: - Create BookCover ViewModel
-        let createBookCoverUseCase = try DIContainer.shared.resolve(CreateBookCoverUseCase.self)
-        let createBookUseCase = try DIContainer.shared.resolve(CreateBookUseCase.self)
-        let deleteBookUseCase = try DIContainer.shared.resolve(DeleteBookUseCase.self)
-        DIContainer.shared.register(
+        let createBookCoverUseCase = try await DIContainer.shared.resolve(CreateBookCoverUseCase.self)
+        let createBookUseCase = try await DIContainer.shared.resolve(CreateBookUseCase.self)
+        let deleteBookUseCase = try await DIContainer.shared.resolve(DeleteBookUseCase.self)
+        await DIContainer.shared.register(
             CreateBookCoverViewModelFactory.self,
             object: CreateBookCoverViewModelFactory(
                 fetchMemorialHouseNameUseCase: fetchMemorialHouseNameUseCase,
@@ -280,8 +282,8 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
         
         // MARK: - Modify BookCover ViewModel
-        let fetchBookCoverUseCase = try DIContainer.shared.resolve(FetchBookCoverUseCase.self)
-        DIContainer.shared.register(
+        let fetchBookCoverUseCase = try await DIContainer.shared.resolve(FetchBookCoverUseCase.self)
+        await DIContainer.shared.register(
             ModifyBookCoverViewModelFactory.self,
             object: ModifyBookCoverViewModelFactory(
                 fetchMemorialHouseNameUseCase: fetchMemorialHouseNameUseCase,
@@ -291,20 +293,20 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
         
         // MARK: - Book ViewModel
-        let fetchBookUseCase = try DIContainer.shared.resolve(FetchBookUseCase.self)
-        DIContainer.shared.register(
+        let fetchBookUseCase = try await DIContainer.shared.resolve(FetchBookUseCase.self)
+        await DIContainer.shared.register(
             BookViewModelFactory.self,
             object: BookViewModelFactory(fetchBookUseCase: fetchBookUseCase)
         )
         
         // MARK: - EditBook ViewModel
-        let updateBookUseCase = try DIContainer.shared.resolve(UpdateBookUseCase.self)
-        let storeMediaUseCase = try DIContainer.shared.resolve(PersistentlyStoreMediaUseCase.self)
-        let deleteTemporaryMediaUseCase = try DIContainer.shared.resolve(DeleteTemporaryMediaUseCase.self)
-        let createMediaUseCase = try DIContainer.shared.resolve(CreateMediaUseCase.self)
-        let fetchMediaUseCase = try DIContainer.shared.resolve(FetchMediaUseCase.self)
-        let deleteMediaUseCase = try DIContainer.shared.resolve(DeleteMediaUseCase.self)
-        DIContainer.shared.register(
+        let updateBookUseCase = try await DIContainer.shared.resolve(UpdateBookUseCase.self)
+        let storeMediaUseCase = try await DIContainer.shared.resolve(PersistentlyStoreMediaUseCase.self)
+        let deleteTemporaryMediaUseCase = try await DIContainer.shared.resolve(DeleteTemporaryMediaUseCase.self)
+        let createMediaUseCase = try await DIContainer.shared.resolve(CreateMediaUseCase.self)
+        let fetchMediaUseCase = try await DIContainer.shared.resolve(FetchMediaUseCase.self)
+        let deleteMediaUseCase = try await DIContainer.shared.resolve(DeleteMediaUseCase.self)
+        await DIContainer.shared.register(
             EditBookViewModelFactory.self,
             object: EditBookViewModelFactory(
                 fetchBookUseCase: fetchBookUseCase,
@@ -318,14 +320,14 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
         
         // MARK: - Page ViewModel
-        DIContainer.shared.register(
+        await DIContainer.shared.register(
             ReadPageViewModelFactory.self,
             object: ReadPageViewModelFactory(fetchMediaUseCase: fetchMediaUseCase)
         )
         
         // MARK: - CreateMediaViewModel
-        let temporaryStoreMediaUseCase = try DIContainer.shared.resolve(TemporaryStoreMediaUseCase.self)
-        DIContainer.shared.register(
+        let temporaryStoreMediaUseCase = try await DIContainer.shared.resolve(TemporaryStoreMediaUseCase.self)
+        await DIContainer.shared.register(
             CreateAudioViewModelFactory.self,
             object: CreateAudioViewModelFactory(
                 temporaryStoreMediaUseCase: temporaryStoreMediaUseCase

--- a/MemorialHouse/MHCore/MHCore/DIContainer.swift
+++ b/MemorialHouse/MHCore/MHCore/DIContainer.swift
@@ -1,5 +1,5 @@
-public final class DIContainer {
-    @MainActor public static let shared = DIContainer()
+public actor DIContainer {
+    public static let shared = DIContainer()
     private var objects: [String: Any] = [:]
     
     private init() {}

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Audio/Audio/View/CreateAudioViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Audio/Audio/View/CreateAudioViewController.swift
@@ -291,12 +291,10 @@ final class CreateAudioViewController: UIViewController {
     
     // MARK: - Helper
     private func requestMicrophonePermission() {
-        Task {
-            AVAudioSession.sharedInstance().requestRecordPermission { @Sendable granted in
-                Task { @MainActor in
-                    if !granted {
-                        self.showRedirectSettingAlert(with: .audio)
-                    }
+        AVAudioSession.sharedInstance().requestRecordPermission { @Sendable granted in
+            Task { @MainActor in
+                if !granted {
+                    self.showRedirectSettingAlert(with: .audio)
                 }
             }
         }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Audio/Audio/View/CreateAudioViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Audio/Audio/View/CreateAudioViewController.swift
@@ -105,12 +105,9 @@ final class CreateAudioViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        guard let viewModelFactory = try? DIContainer.shared.resolve(CreateAudioViewModelFactory.self) else {
-            return nil
-        }
-        self.viewModel = viewModelFactory.make { _ in }
-        super.init(nibName: nil, bundle: nil)
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - Life Cycle

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Audio/Audio/ViewModel/CreateAudioViewModelFactory.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Audio/Audio/ViewModel/CreateAudioViewModelFactory.swift
@@ -1,7 +1,7 @@
 import MHFoundation
 import MHDomain
 
-public struct CreateAudioViewModelFactory {
+public struct CreateAudioViewModelFactory: Sendable {
     private let temporaryStoreMediaUseCase: TemporaryStoreMediaUseCase
     
     public init(temporaryStoreMediaUseCase: TemporaryStoreMediaUseCase) {

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Audio/Player/View/MHAudioPlayerView.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Audio/Player/View/MHAudioPlayerView.swift
@@ -11,7 +11,7 @@ final class MHAudioPlayerView: UIView {
     private let input = PassthroughSubject<AudioPlayerViewModel.Input, Never>()
     private var cancellables = Set<AnyCancellable>()
     // audio
-    private nonisolated(unsafe) var audioPlayer: AVAudioPlayer?
+    private var audioPlayer: AVAudioPlayer?
     private var audioPlayState: AudioPlayState = .pause {
         didSet {
             switch audioPlayState {
@@ -171,8 +171,8 @@ final class MHAudioPlayerView: UIView {
     private func startTimer() {
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            guard let audioPlayer = self?.audioPlayer else { return }
             Task { @MainActor in
+                guard let audioPlayer = self?.audioPlayer else { return }
                 if audioPlayer.isPlaying {
                     self?.updatePlayAudioProgress()
                 }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Audio/Player/View/MHAudioPlayerView.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Audio/Player/View/MHAudioPlayerView.swift
@@ -207,7 +207,7 @@ extension MHAudioPlayerView: AVAudioPlayerDelegate {
     }
 }
 
-extension MHAudioPlayerView: @preconcurrency MediaAttachable {
+extension MHAudioPlayerView: MediaAttachable {
     func configureSource(with mediaDescription: MediaDescription, data: Data) {
         audioPlayer = try? AVAudioPlayer(data: data)
         guard let audioPlayer else { return }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Book/View/BookViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Book/View/BookViewController.swift
@@ -14,6 +14,8 @@ final class BookViewController: UIViewController {
     private let viewModel: BookViewModel
     private let input = PassthroughSubject<BookViewModel.Input, Never>()
     private var cancellables = Set<AnyCancellable>()
+    private var nextPageViewController: ReadPageViewController?
+    private var previousPageViewController: ReadPageViewController?
     
     // MARK: - Initialize
     init(viewModel: BookViewModel) {
@@ -21,10 +23,9 @@ final class BookViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        guard let viewModel = try? DIContainer.shared.resolve(BookViewModel.self) else { return nil }
-        self.viewModel = viewModel
-        super.init(nibName: nil, bundle: nil)
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - View Life Cycle
@@ -56,9 +57,9 @@ final class BookViewController: UIViewController {
                 self?.title = bookTitle
             case .loadFirstPage(let page):
                 guard let page else { return }
-                self?.configureFirstPageViewController(firstPage: page)
+                Task { await self?.configureFirstPageViewController(firstPage: page) }
             case .moveToEdit(let bookID, let bookTitle):
-                self?.presentEditBookView(bookID: bookID, bookTitle: bookTitle)
+                Task { await self?.presentEditBookView(bookID: bookID, bookTitle: bookTitle) }
             }
         }
         .store(in: &cancellables)
@@ -114,14 +115,25 @@ final class BookViewController: UIViewController {
     }
     
     // MARK: - Set PageviewController
-    private func configureFirstPageViewController(firstPage: Page) {
-        guard let startViewController = makeNewPageViewController(page: firstPage) else { return }
+    private func configureFirstPageViewController(firstPage: Page) async {
+        guard let startViewController = await makeNewPageViewController(page: firstPage) else { return }
         let viewControllers = [startViewController]
         pageViewController.setViewControllers(viewControllers, direction: .forward, animated: true, completion: nil)
     }
     
-    private func makeNewPageViewController(page: Page) -> ReadPageViewController? {
-        guard let readPageViewModelFactory = try? DIContainer.shared.resolve(ReadPageViewModelFactory.self) else {
+    private func prepareAdjacentViewControllers() {
+        Task {
+            if let nextPage = viewModel.nextPage {
+                nextPageViewController = await makeNewPageViewController(page: nextPage)
+            }
+            if let previousPage = viewModel.previousPage {
+                previousPageViewController = await makeNewPageViewController(page: previousPage)
+            }
+        }
+    }
+    
+    private func makeNewPageViewController(page: Page) async -> ReadPageViewController? {
+        guard let readPageViewModelFactory = try? await DIContainer.shared.resolve(ReadPageViewModelFactory.self) else {
             return nil
         }
         let readPageViewModel = readPageViewModelFactory.make(bookID: viewModel.identifier, page: page)
@@ -130,9 +142,9 @@ final class BookViewController: UIViewController {
     }
     
     // MARK: - PresentEditBookView
-    private func presentEditBookView(bookID: UUID, bookTitle: String) {
+    private func presentEditBookView(bookID: UUID, bookTitle: String) async {
         do {
-            let editBookViewModelFactory = try DIContainer.shared.resolve(EditBookViewModelFactory.self)
+            let editBookViewModelFactory = try await DIContainer.shared.resolve(EditBookViewModelFactory.self)
             let editBookViewModel = editBookViewModelFactory.make(bookID: bookID, bookTitle: bookTitle)
             let editBookViewController = EditBookViewController(viewModel: editBookViewModel, mode: .modify)
             navigationController?.pushViewController(editBookViewController, animated: true)
@@ -144,7 +156,16 @@ final class BookViewController: UIViewController {
 
 // MARK: - UIPageViewControllerDelegate
 extension BookViewController: UIPageViewControllerDelegate {
-    // TODO: - Page transition 감지
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        didFinishAnimating finished: Bool,
+        previousViewControllers: [UIViewController],
+        transitionCompleted completed: Bool
+    ) {
+        if completed {
+            prepareAdjacentViewControllers()
+        }
+    }
 }
 
 // MARK: - UIPageViewControllerDataSource
@@ -156,7 +177,9 @@ extension BookViewController: UIPageViewControllerDataSource {
         guard let previousPage = viewModel.previousPage else { return nil }
         input.send(.loadPreviousPage)
         
-        return makeNewPageViewController(page: previousPage)
+        let vc = previousPageViewController
+        previousPageViewController = nil
+        return vc
     }
     
     func pageViewController(
@@ -166,6 +189,8 @@ extension BookViewController: UIPageViewControllerDataSource {
         guard let nextPage = viewModel.nextPage else { return nil }
         input.send(.loadNextPage)
         
-        return makeNewPageViewController(page: nextPage)
+        let vc = nextPageViewController
+        nextPageViewController = nil
+        return vc
     }
 }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Book/ViewModel/BookViewModelFactory.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Book/ViewModel/BookViewModelFactory.swift
@@ -1,7 +1,7 @@
 import MHFoundation
 import MHDomain
 
-public struct BookViewModelFactory {
+public struct BookViewModelFactory: Sendable {
     private let fetchBookUseCase: FetchBookUseCase
     
     public init(

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/BookCover/View/BookCoverViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/BookCover/View/BookCoverViewController.swift
@@ -176,7 +176,7 @@ final class BookCoverViewController: UIViewController {
                 case .bookCategory(let category):
                     self?.setCategorySelectionButton(category: category)
                 case .moveToNext(let bookID):
-                    self?.presentEditBookView(bookID: bookID)
+                    Task { await self?.presentEditBookView(bookID: bookID) }
                 case .moveToHome:
                     self?.navigationController?.popViewController(animated: true)
                 case .settingFailure:
@@ -229,10 +229,10 @@ final class BookCoverViewController: UIViewController {
     }
     
     // MARK: - Present EditBookViewController
-    private func presentEditBookView(bookID: UUID) {
+    private func presentEditBookView(bookID: UUID) async {
         do {
             guard let bookTitle = bookTitleTextField.text?.localized() else { return }
-            let editBookViewModelFactory = try DIContainer.shared.resolve(EditBookViewModelFactory.self)
+            let editBookViewModelFactory = try await DIContainer.shared.resolve(EditBookViewModelFactory.self)
             let editBookViewModel = editBookViewModelFactory.make(bookID: bookID, bookTitle: bookTitle)
             let editBookViewController = EditBookViewController(viewModel: editBookViewModel)
             navigationController?.pushViewController(editBookViewController, animated: true)
@@ -397,7 +397,7 @@ extension BookCoverViewController {
         imageSelectionButton.addAction(selectPhotoAction, for: .touchUpInside)
         
         let selectCategoryAction = UIAction { [weak self] _ in
-            self?.presentCategorySelectionView()
+            Task { await self?.presentCategorySelectionView() }
         }
         categorySelectionButton.addAction(selectCategoryAction, for: .touchUpInside)
     }
@@ -479,9 +479,9 @@ extension BookCoverViewController: UITextFieldDelegate {
 
 // MARK: - Category Bottom Sheet
 extension BookCoverViewController: BookCategoryViewControllerDelegate {
-    private func presentCategorySelectionView() {
+    private func presentCategorySelectionView() async {
         do {
-            let categoryViewModelFactory = try DIContainer.shared.resolve(BookCategoryViewModelFactory.self)
+            let categoryViewModelFactory = try await DIContainer.shared.resolve(BookCategoryViewModelFactory.self)
             let categoryViewModel = categoryViewModelFactory.makeForCreateBook()
             let categoryViewController = BookCategoryViewController(viewModel: categoryViewModel)
             let navigationController = UINavigationController(rootViewController: categoryViewController)

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/BookCover/ViewModel/CreateBookCoverViewModel.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/BookCover/ViewModel/CreateBookCoverViewModel.swift
@@ -58,7 +58,16 @@ final class CreateBookCoverViewModel: ViewModelType {
     }
     
     func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
-        input.sink { [weak self] event in
+        let shared = input.share()
+        
+        shared
+            .filter { event in
+                if case .saveBookCover = event {
+                    return false
+                }
+                return true
+            }
+            .sink { [weak self] event in
             switch event {
             case .setBookCover:
                 self?.setBookColor(nowIndex: 0)
@@ -71,15 +80,27 @@ final class CreateBookCoverViewModel: ViewModelType {
                 self?.setBookImageData(imageData: bookImage)
             case .changedBookCategory(let category):
                 self?.setBookCategory(category: category)
-            case .saveBookCover:
-                Task { try await self?.saveBookCover() }
             case .deleteBookCover:
                 Task {
                     try await self?.deleteBookCover()
                     self?.output.send(.moveToHome)
                 }
+            default:
+                break
             }
         }.store(in: &cancellables)
+        
+        shared
+            .filter { event in
+                if case .saveBookCover = event {
+                    return true
+                }
+                return false
+            }
+            .sink { [weak self] _ in
+                Task { try await self?.saveBookCover() }
+            }
+            .store(in: &cancellables)
         
         return output.eraseToAnyPublisher()
     }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/BookCover/ViewModel/CreateBookCoverViewModelFactory.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/BookCover/ViewModel/CreateBookCoverViewModelFactory.swift
@@ -1,7 +1,7 @@
 import MHFoundation
 import MHDomain
 
-public struct CreateBookCoverViewModelFactory {
+public struct CreateBookCoverViewModelFactory: Sendable {
     private let fetchMemorialHouseNameUseCase: FetchMemorialHouseNameUseCase
     private let createBookCoverUseCase: CreateBookCoverUseCase
     private let deleteBookCoverUseCase: DeleteBookCoverUseCase

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/BookCover/ViewModel/ModifyBookCoverViewmodelFactory.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/BookCover/ViewModel/ModifyBookCoverViewmodelFactory.swift
@@ -1,7 +1,7 @@
 import MHFoundation
 import MHDomain
 
-public struct ModifyBookCoverViewModelFactory {
+public struct ModifyBookCoverViewModelFactory: Sendable {
     private let fetchMemorialHouseNameUseCase: FetchMemorialHouseNameUseCase
     private let fetchBookCoverUseCase: FetchBookCoverUseCase
     private let updateBookCoverUseCase: UpdateBookCoverUseCase

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Category/View/BookCategoryViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Category/View/BookCategoryViewController.swift
@@ -27,12 +27,9 @@ final class BookCategoryViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        guard let viewModelFactory = try? DIContainer.shared.resolve(BookCategoryViewModelFactory.self) else {
-            return nil
-        }
-        self.viewModel = viewModelFactory.makeForHome()
-        super.init(coder: coder)
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - View Life Cycle

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Category/ViewModel/BookCategoryViewModelFactory.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Category/ViewModel/BookCategoryViewModelFactory.swift
@@ -1,6 +1,6 @@
 import MHDomain
 
-public struct BookCategoryViewModelFactory {
+public struct BookCategoryViewModelFactory: Sendable {
     let createBookCategoryUseCase: CreateBookCategoryUseCase
     let fetchBookCategoriesUseCase: FetchBookCategoriesUseCase
     let updateBookCategoryUseCase: UpdateBookCategoryUseCase

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/CustomAlbum/View/CustomAlbumViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/CustomAlbum/View/CustomAlbumViewController.swift
@@ -278,23 +278,21 @@ extension CustomAlbumViewController: UICollectionViewDelegate {
     }
     
     private func handleImageSelection(with asset: PHAsset) {
-        Task {
-            await LocalPhotoManager.shared.requestThumbnailImage(with: asset) { [weak self] image in
-                guard let self,
-                      let image else { return }
-                self.moveToEditPhotoView(image: image, creationDate: asset.creationDate ?? .now)
-            }
+        LocalPhotoManager().requestThumbnailImage(with: asset) { [weak self] image in
+            guard let self,
+                  let image else { return }
+            self.moveToEditPhotoView(image: image, creationDate: asset.creationDate ?? .now)
         }
     }
     
     private func handleVideoSelection(with asset: PHAsset) {
-        Task {
-            if let videoURL = await LocalPhotoManager.shared.requestVideoURL(with: asset) {
-                MHLogger.info("\(#function) 비디오 URL: \(videoURL)")
-                self.moveToEditVideoView(url: videoURL)
-            } else {
+        LocalPhotoManager().requestVideoURL(with: asset) { videoURL in
+            guard let videoURL else {
                 self.showErrorAlert(with: "비디오 URL을 가져올 수 없습니다.")
+                return
             }
+            MHLogger.info("\(#function) 비디오 URL: \(videoURL)")
+            self.moveToEditVideoView(url: videoURL)
         }
     }
 }
@@ -324,11 +322,9 @@ extension CustomAlbumViewController: UICollectionViewDataSource {
             guard let asset = viewModel.photoAsset?[indexPath.item - 1] else { return cell }
             cell.representedAssetIdentifier = asset.localIdentifier
             let cellSize = cell.bounds.size
-            Task {
-                await LocalPhotoManager.shared.requestThumbnailImage(with: asset, cellSize: cellSize) { image in
-                    if cell.representedAssetIdentifier == asset.localIdentifier {
-                        cell.setPhoto(image)
-                    }
+            LocalPhotoManager().requestThumbnailImage(with: asset, cellSize: cellSize) { image in
+                if cell.representedAssetIdentifier == asset.localIdentifier {
+                    cell.setPhoto(image)
                 }
             }
         }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/CustomAlbum/ViewModel/LocalPhotoManager.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/CustomAlbum/ViewModel/LocalPhotoManager.swift
@@ -1,9 +1,7 @@
 import UIKit
 import Photos
 
-actor LocalPhotoManager {
-    static let shared = LocalPhotoManager()
-    
+struct LocalPhotoManager {
     private let imageManager = PHCachingImageManager()
     private let imageRequestOptions: PHImageRequestOptions = {
         let options = PHImageRequestOptions()
@@ -13,8 +11,6 @@ actor LocalPhotoManager {
         
         return options
     }()
-    
-    private init() { }
     
     func requestThumbnailImage(
         with asset: PHAsset?,
@@ -41,18 +37,14 @@ actor LocalPhotoManager {
     }
     
     func requestVideoURL(
-        with asset: PHAsset
-    ) async -> URL? {
-        await withCheckedContinuation { continuation in
-            let options = PHVideoRequestOptions()
-            options.version = .current
-            imageManager.requestAVAsset(forVideo: asset, options: options) { avAsset, _, _ in
-                if let urlAsset = avAsset as? AVURLAsset {
-                    continuation.resume(returning: urlAsset.url)
-                } else {
-                    continuation.resume(returning: nil)
-                }
-            }
+        with asset: PHAsset,
+        completion: @escaping @MainActor (URL?) -> Void
+    ) {
+        let options = PHVideoRequestOptions()
+        options.version = .current
+        imageManager.requestAVAsset(forVideo: asset, options: options) { avAsset, _, _ in
+            let url = (avAsset as? AVURLAsset)?.url
+            Task { await completion(url) }
         }
     }
 }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHPolaroidPhotoView.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHPolaroidPhotoView.swift
@@ -85,8 +85,7 @@ final class MHPolaroidPhotoView: UIView {
     }
 }
 
-// TODO: - PreConcurrency 제거..?
-extension MHPolaroidPhotoView: @preconcurrency MediaAttachable {
+extension MHPolaroidPhotoView: MediaAttachable {
     func configureSource(with mediaDescription: MediaDescription, data: Data) {
         var caption: String?
         if let captionString = mediaDescription.attributes?[Constant.photoCaption] as? String {

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHVideoView.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Design/MHVideoView.swift
@@ -29,7 +29,7 @@ final class MHVideoView: UIView {
     }
 }
 
-extension MHVideoView: @preconcurrency MediaAttachable {
+extension MHVideoView: MediaAttachable {
     func configureSource(with mediaDescription: MediaDescription, data: Data) {
         let player = AVPlayer()
         configurePlayer(player: player)

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/EditBook/View/EditBookViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/EditBook/View/EditBookViewController.swift
@@ -94,12 +94,9 @@ final class EditBookViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        guard let viewModel = try? DIContainer.shared.resolve(EditBookViewModelFactory.self) else { return nil }
-        self.viewModel = viewModel.make(bookID: .init(), bookTitle: "")
-        self.mode = .create
-        
-        super.init(coder: coder)
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - LifeCycle
@@ -252,65 +249,77 @@ final class EditBookViewController: UIViewController {
             }
             .store(in: &cancellables)
     }
+    
     private func configureButtonAction() {
-        let addImageAction = UIAction { [weak self] _ in
-            let albumViewModel = CustomAlbumViewModel()
-            let customAlbumViewController = CustomAlbumViewController(
-                viewModel: albumViewModel,
-                mediaType: .image,
-                mode: .editPage,
-                videoSelectCompletionHandler: nil
-            ) { imageData, creationDate, caption in
-                let attributes: [String: any Sendable] = [
-                    Constant.photoCreationDate: creationDate?.toString(),
-                    Constant.photoCaption: caption
-                ]
-                self?.input.send(.didAddMediaWithData(type: .image, attributes: attributes, data: imageData))
-            }
-            let navigationViewController = UINavigationController(rootViewController: customAlbumViewController)
-            navigationViewController.modalPresentationStyle = .fullScreen
-            self?.present(navigationViewController, animated: true)
-        }
-        addImageButton.addAction(addImageAction, for: .touchUpInside)
+        addImageButton.addAction(UIAction { [weak self] _ in
+            self?.handleAddImageTapped()
+        }, for: .touchUpInside)
         
-        let addVideoAction = UIAction { [weak self] _ in
-            let albumViewModel = CustomAlbumViewModel()
-            let customAlbumViewController = CustomAlbumViewController(
-                viewModel: albumViewModel,
-                mediaType: .video,
-                videoSelectCompletionHandler: { url in
-                    self?.input.send(.didAddMediaInURL(type: .video, attributes: nil, url: url))
-                }
-            )
-            
-            let navigationViewController = UINavigationController(rootViewController: customAlbumViewController)
-            navigationViewController.modalPresentationStyle = .fullScreen
-            self?.present(navigationViewController, animated: true)
-        }
-        addVideoButton.addAction(addVideoAction, for: .touchUpInside)
+        addVideoButton.addAction(UIAction { [weak self] _ in
+            self?.handleAddVideoTapped()
+        }, for: .touchUpInside)
         
-        let addAudioAction = UIAction { [weak self] _ in
-            guard let self else { return }
-            guard let audioViewModelFactory = try? DIContainer.shared.resolve(CreateAudioViewModelFactory.self) else { return }
-            let audioViewModel = audioViewModelFactory.make { [weak self] mediaDescription in
-                guard let mediaDescription else { return }
-                self?.input.send(.didAddMediaInTemporary(media: mediaDescription))
-            }
-            let audioViewController = CreateAudioViewController(viewModel: audioViewModel)
-            
-            if let sheet = audioViewController.sheetPresentationController {
-                sheet.detents = [.custom { detent in 0.35 * detent.maximumDetentValue }]
-                sheet.prefersGrabberVisible = true
-            }
-            
-            present(audioViewController, animated: true)
-        }
-        addAudioButton.addAction(addAudioAction, for: .touchUpInside)
+        addAudioButton.addAction(UIAction { [weak self] _ in
+            Task { await self?.handleAddAudioTapped() }
+        }, for: .touchUpInside)
         
-        let addPageAction = UIAction { [weak self] _ in
-            self?.input.send(.addPageButtonTapped)
+        addPageButton.addAction(UIAction { [weak self] _ in
+            self?.handleAddPageTapped()
+        }, for: .touchUpInside)
+    }
+
+    private func handleAddImageTapped() {
+        let albumViewModel = CustomAlbumViewModel()
+        let customAlbumViewController = CustomAlbumViewController(
+            viewModel: albumViewModel,
+            mediaType: .image,
+            mode: .editPage,
+            videoSelectCompletionHandler: nil
+        ) { [weak self] imageData, creationDate, caption in
+            let attributes: [String: any Sendable] = [
+                Constant.photoCreationDate: creationDate?.toString(),
+                Constant.photoCaption: caption
+            ]
+            self?.input.send(.didAddMediaWithData(type: .image, attributes: attributes, data: imageData))
         }
-        addPageButton.addAction(addPageAction, for: .touchUpInside)
+        let navigationViewController = UINavigationController(rootViewController: customAlbumViewController)
+        navigationViewController.modalPresentationStyle = .fullScreen
+        present(navigationViewController, animated: true)
+    }
+
+    private func handleAddVideoTapped() {
+        let albumViewModel = CustomAlbumViewModel()
+        let customAlbumViewController = CustomAlbumViewController(
+            viewModel: albumViewModel,
+            mediaType: .video,
+            videoSelectCompletionHandler: { [weak self] url in
+                self?.input.send(.didAddMediaInURL(type: .video, attributes: nil, url: url))
+            }
+        )
+        
+        let navigationViewController = UINavigationController(rootViewController: customAlbumViewController)
+        navigationViewController.modalPresentationStyle = .fullScreen
+        present(navigationViewController, animated: true)
+    }
+
+    private func handleAddAudioTapped() async {
+        guard let audioViewModelFactory = try? await DIContainer.shared.resolve(CreateAudioViewModelFactory.self) else { return }
+        let audioViewModel = audioViewModelFactory.make { [weak self] mediaDescription in
+            guard let mediaDescription else { return }
+            self?.input.send(.didAddMediaInTemporary(media: mediaDescription))
+        }
+        let audioViewController = CreateAudioViewController(viewModel: audioViewModel)
+        
+        if let sheet = audioViewController.sheetPresentationController {
+            sheet.detents = [.custom { detent in 0.35 * detent.maximumDetentValue }]
+            sheet.prefersGrabberVisible = true
+        }
+        
+        present(audioViewController, animated: true)
+    }
+
+    private func handleAddPageTapped() {
+        input.send(.addPageButtonTapped)
     }
     
     // MARK: - Helper

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/EditBook/View/MediaAttachable.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/EditBook/View/MediaAttachable.swift
@@ -1,6 +1,7 @@
 import MHFoundation
 import MHDomain
 
+@MainActor
 protocol MediaAttachable {
     func configureSource(with mediaDescription: MediaDescription, data: Data)
     func configureSource(with mediaDescription: MediaDescription, url: URL)

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/EditBook/View/MediaAttachment.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/EditBook/View/MediaAttachment.swift
@@ -49,9 +49,12 @@ final class MediaAttachment: NSTextAttachment {
     }
     
     // MARK: - Method
+    @MainActor
     func configure(with data: Data) {
         view.configureSource(with: mediaDescription, data: data)
     }
+    
+    @MainActor
     func configure(with url: URL) {
         view.configureSource(with: mediaDescription, url: url)
     }

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/EditBook/ViewModel/EditBookViewModelFactory.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/EditBook/ViewModel/EditBookViewModelFactory.swift
@@ -1,7 +1,7 @@
 import MHFoundation
 import MHDomain
 
-public struct EditBookViewModelFactory {
+public struct EditBookViewModelFactory: Sendable {
     private let fetchBookUseCase: FetchBookUseCase
     private let updateBookUseCase: UpdateBookUseCase
     private let storeMediaUseCase: PersistentlyStoreMediaUseCase

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Home/View/HomeViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Home/View/HomeViewController.swift
@@ -50,10 +50,9 @@ public final class HomeViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        guard let viewModelFactory = try? DIContainer.shared.resolve(HomeViewModelFactory.self) else { return nil }
-        self.viewModel = viewModelFactory.make()
-        super.init(coder: coder)
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - View LifeCycle
@@ -123,29 +122,11 @@ public final class HomeViewController: UIViewController {
     private func configureAction() {
         // MARK: 카테고리 화면으로 전환 버튼
         categorySelectButton.addAction(UIAction { [weak self] _ in
-            do {
-                guard let self else { return }
-                let categoryViewModelFactory = try DIContainer.shared.resolve(BookCategoryViewModelFactory.self)
-                let categoryViewModel = categoryViewModelFactory.makeForHome()
-                categoryViewModel.setup(currentCategory: self.currentCategory)
-                let categoryViewController = BookCategoryViewController(viewModel: categoryViewModel)
-                categoryViewController.delegate = self
-                let navigationController = UINavigationController(rootViewController: categoryViewController)
-                
-                if let sheet = navigationController.sheetPresentationController {
-                    sheet.detents = [.medium(), .large()]
-                }
-                
-                self.present(navigationController, animated: true)
-            } catch let error as MHCoreError {
-                MHLogger.error(error.description)
-            } catch {
-                MHLogger.error(error.localizedDescription)
-            }
+            Task { await self?.presentCategorySheet() }
         }, for: .touchUpInside)
         
         makingBookFloatingButton.addAction(UIAction { [weak self] _ in
-            self?.moveBookCoverViewController()
+            Task { await self?.moveBookCoverViewController() }
         }, for: .touchUpInside)
         
         navigationBar.configureSettingAction(action: UIAction { [weak self] _ in
@@ -156,9 +137,9 @@ public final class HomeViewController: UIViewController {
         })
     }
     
-    private func moveBookCoverViewController(bookID: UUID? = nil) {
+    private func moveBookCoverViewController(bookID: UUID? = nil) async {
         if let bookID {
-            let viewModelFactory = try? DIContainer.shared.resolve(ModifyBookCoverViewModelFactory.self)
+            let viewModelFactory = try? await DIContainer.shared.resolve(ModifyBookCoverViewModelFactory.self)
             let modifyBookCoverViewModel = viewModelFactory?.make(bookID: bookID)
             let modifyBookCoverViewController = BookCoverViewController(
                 modifyViewModel: modifyBookCoverViewModel,
@@ -166,7 +147,7 @@ public final class HomeViewController: UIViewController {
             )
             navigationController?.pushViewController(modifyBookCoverViewController, animated: true)
         } else {
-            let viewModelFactory = try? DIContainer.shared.resolve(CreateBookCoverViewModelFactory.self)
+            let viewModelFactory = try? await DIContainer.shared.resolve(CreateBookCoverViewModelFactory.self)
             let createBookCoverViewModel = viewModelFactory?.make(bookCount: viewModel.currentBookCovers.count)
             let createBookCoverViewController = BookCoverViewController(
                 createViewModel: createBookCoverViewModel,
@@ -205,6 +186,27 @@ public final class HomeViewController: UIViewController {
         categorySelectButton.setLeading(anchor: currentCategoryLabel.trailingAnchor, constant: 8)
         categorySelectButton.setCenterY(view: currentCategoryLabel)
         categorySelectButton.setWidth(20)
+    }
+    
+    private func presentCategorySheet() async {
+        do {
+            let categoryViewModelFactory = try await DIContainer.shared.resolve(BookCategoryViewModelFactory.self)
+            let categoryViewModel = categoryViewModelFactory.makeForHome()
+            categoryViewModel.setup(currentCategory: currentCategory)
+            let categoryViewController = BookCategoryViewController(viewModel: categoryViewModel)
+            categoryViewController.delegate = self
+            let navigationController = UINavigationController(rootViewController: categoryViewController)
+            
+            if let sheet = navigationController.sheetPresentationController {
+                sheet.detents = [.medium(), .large()]
+            }
+            
+            present(navigationController, animated: true)
+        } catch let error as MHCoreError {
+            MHLogger.error(error.description)
+        } catch {
+            MHLogger.error(error.localizedDescription)
+        }
     }
 }
 
@@ -281,13 +283,13 @@ extension HomeViewController: UICollectionViewDataSource {
         )
         cell.configureButtonAction(
             bookCoverAction: { [weak self] in
-                self?.bookCoverTapped(indexPath: indexPath)
+                Task { await self?.bookCoverTapped(indexPath: indexPath) }
             },
             likeButtonAction: { [weak self] in
                 self?.input.send(.likeButtonTapped(bookId: bookCover.id))
             },
             dropDownButtonEditAction: { [weak self] in
-                self?.moveBookCoverViewController(bookID: bookCover.id)
+                Task { await self?.moveBookCoverViewController(bookID: bookCover.id) }
             },
             dropDownButtonDeleteAction: { [weak self] in
                 self?.input.send(.deleteBookCover(bookId: bookCover.id))
@@ -297,15 +299,19 @@ extension HomeViewController: UICollectionViewDataSource {
         return cell
     }
     
-    private func bookCoverTapped(indexPath: IndexPath) {
-        let bookID = viewModel.currentBookCovers[indexPath.row].id
-        let bookTitle = viewModel.currentBookCovers[indexPath.row].title
-        guard let bookViewModelFactory = try? DIContainer.shared.resolve(BookViewModelFactory.self) else {
-            return
+    private func bookCoverTapped(indexPath: IndexPath) async {
+        do {
+            let bookID = viewModel.currentBookCovers[indexPath.row].id
+            let bookTitle = viewModel.currentBookCovers[indexPath.row].title
+            let bookViewModelFactory = try await DIContainer.shared.resolve(BookViewModelFactory.self)
+            let bookViewModel = bookViewModelFactory.make(bookID: bookID, bookTitle: bookTitle)
+            let bookViewController = BookViewController(viewModel: bookViewModel)
+            navigationController?.pushViewController(bookViewController, animated: true)
+        } catch let error as MHCoreError {
+            MHLogger.error(error.description)
+        } catch {
+            MHLogger.error(error.localizedDescription)
         }
-        let bookViewModel = bookViewModelFactory.make(bookID: bookID, bookTitle: bookTitle)
-        let bookViewController = BookViewController(viewModel: bookViewModel)
-        navigationController?.pushViewController(bookViewController, animated: true)
     }
 }
 

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Home/ViewModel/HomeViewModelFactory.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Home/ViewModel/HomeViewModelFactory.swift
@@ -1,6 +1,6 @@
 import MHDomain
 
-public struct HomeViewModelFactory {
+public struct HomeViewModelFactory: Sendable {
     let fetchMemorialHouseNameUseCase: FetchMemorialHouseNameUseCase
     let fetchAllBookCoverUseCase: FetchAllBookCoverUseCase
     let updateBookCoverUseCase: UpdateBookCoverUseCase

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Onboarding/OnboardingViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Onboarding/OnboardingViewController.swift
@@ -102,17 +102,17 @@ public final class OnboardingViewController: UIViewController {
     
     private func configureAddActions() {
         skipButton.addAction(UIAction { [weak self] _ in
-            self?.moveToRegister()
+            Task { await self?.moveToRegister() }
         }, for: .touchUpInside)
         
         nextButton.addAction(UIAction { [weak self] _ in
-            self?.handleNextButtonTap()
+            Task { await self?.handleNextButtonTap() }
         }, for: .touchUpInside)
     }
 
-    private func handleNextButtonTap() {
+    private func handleNextButtonTap() async {
         if currentPageIndex == pages.count - 1 {
-            moveToRegister()
+            await moveToRegister()
         } else {
             currentPageIndex += 1
             pageViewController.setViewControllers(
@@ -135,9 +135,9 @@ public final class OnboardingViewController: UIViewController {
         }
     }
     
-    private func moveToRegister() {
+    private func moveToRegister() async {
         do {
-            let viewModelFactory = try DIContainer.shared.resolve(RegisterViewModelFactory.self)
+            let viewModelFactory = try await DIContainer.shared.resolve(RegisterViewModelFactory.self)
             let viewModel = viewModelFactory.make()
             let registerViewController = RegisterViewController(viewModel: viewModel)
             navigationController?.pushViewController(registerViewController, animated: true)
@@ -160,6 +160,7 @@ extension OnboardingViewController: UIPageViewControllerDelegate {
               let index = pages.firstIndex(of: visibleViewController) else { return }
         
         currentPageIndex = index
+        skipButton.isHidden = currentPageIndex == pages.count - 1
     }
 }
 

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/ReadPage/View/ReadPageViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/ReadPage/View/ReadPageViewController.swift
@@ -37,11 +37,9 @@ final class ReadPageViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        guard let viewModelFactory = try? DIContainer.shared.resolve(ReadPageViewModelFactory.self) else { return nil }
-        self.viewModel = viewModelFactory.make(bookID: UUID(), page: Page(metadata: [:], text: ""))
-        
-        super.init(nibName: nil, bundle: nil)
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - View Life Cycle

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/ReadPage/ViewModel/ReadPageViewModelFactory.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/ReadPage/ViewModel/ReadPageViewModelFactory.swift
@@ -1,7 +1,7 @@
 import MHFoundation
 import MHDomain
 
-public struct ReadPageViewModelFactory {
+public struct ReadPageViewModelFactory: Sendable {
     private let fetchMediaUseCase: FetchMediaUseCase
     
     public init(fetchMediaUseCase: FetchMediaUseCase) {

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Register/View/RegisterViewController.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Register/View/RegisterViewController.swift
@@ -67,13 +67,9 @@ public final class RegisterViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        guard let createMHNameUseCase = try? DIContainer.shared.resolve(CreateMemorialHouseNameUseCase.self) else {
-            MHLogger.error("CreateMemorialHouseNameUseCase resolve 실패")
-            return nil
-        }
-        self.viewModel = RegisterViewModel(createMemorialHouseNameUseCase: createMHNameUseCase)
-        super.init(coder: coder)
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - Lifecycle
@@ -109,16 +105,16 @@ public final class RegisterViewController: UIViewController {
             case .registerButtonEnabled(let isEnabled):
                 self?.registerButton.isEnabled = isEnabled
             case .moveToHome:
-                self?.moveHome()
+                Task { await self?.moveHome() }
             case .createFailure(let errorMessage):
                 self?.showErrorAlert(with: errorMessage)
             }
         }.store(in: &cancellables)
     }
     
-    private func moveHome() {
+    private func moveHome() async {
         do {
-            let homeViewModelFactory = try DIContainer.shared.resolve(HomeViewModelFactory.self)
+            let homeViewModelFactory = try await DIContainer.shared.resolve(HomeViewModelFactory.self)
             let homeViewModel = homeViewModelFactory.make()
             let homeViewController = HomeViewController(viewModel: homeViewModel)
             navigationController?.setViewControllers([homeViewController], animated: true)

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Register/ViewModel/RegisterViewModel.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Register/ViewModel/RegisterViewModel.swift
@@ -45,7 +45,6 @@ public final class RegisterViewModel: ViewModelType {
         output.send(.registerButtonEnabled(isEnabled: !text.isEmpty && text.count < 11))
     }
     
-    @MainActor
     private func registerButtonTapped(with memorialHouseName: String) async {
         do {
             try await createMemorialHouseNameUseCase.execute(with: memorialHouseName)

--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Register/ViewModel/RegisterViewModelFactory.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Register/ViewModel/RegisterViewModelFactory.swift
@@ -1,6 +1,6 @@
 import MHDomain
 
-public struct RegisterViewModelFactory {
+public struct RegisterViewModelFactory: Sendable {
     private let createMemorialHouseNameUseCase: CreateMemorialHouseNameUseCase
     
     public init(


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #166 


<br>

## ⏰ 작업 시간
<!-- 해당 작업이 걸린 시간을 작성해주세요 -->

|예상 시간|실제 걸린 시간|
|:-:|:-:|
|3|3.5|

## 📝 작업 내용
<!-- 본 PR에서 작업한 내용을 적어주세요 -->
- [x]  MainActor, Sendable, unsafe, preconcurrency 싸지른거 정리
- [x]  LocalPhotoManager를 actor 타입에서 struct로 전환
- [x]  DIContainer actor 타입으로 전환


## ⚽️ 트러블 슈팅
<!-- 개발 과정에서 발생한 문제를 노션에 작성하고, 그 내용을 여기에도 올려주세요 ! -->
# DIContainer를 Class → Actor로 변경

## 배경

기존에는 DIContainer가 싱글톤 형태로 MainActor영역에서 사용되었다.

```swift
public final class DIContainer {
    **@MainActor** public static let shared = DIContainer()
    private var objects: [String: Any] = [:]
    
    private init() {}
		...
}
```

MainActor의 역할이 UI를 구동하는 역할을 수행해야하는데, DIContainer는 그와 관련이 없다?

unsafe로 해도, 어차피 우리가 알아서 잘 쓰니까 상관없지 않을까? (write 신델리에서 하고, read는 상관없으니까) → DataRace가 발생하지 않는다.

⇒ 새로운 개발자가? write를 이상한데서 하면?

- 꺼내서 쓰면 VM가 class니까 같은 인스턴스를 다른 곳들에서 동시에 참조하는 문제가 발생할 수 있다.
    - 이것때문에 Factory 넣은 거긴함
    - 그런데 말입니다.
    - 새로운 개발자가 Factory로 안해버린다면?

이러한 휴먼에러 방지하고자 Actor를 쓰는 거다.

**Class(MainActor)에서 잘 쓰고 있었죠… Actor로 바꾸는 이유는?**

- MainActor는 main thread에서 UI관련 작업을 하는 actor다.
- DIContainer의 역할은 “의존성 관리”다.
- 즉, DIContainer는 반드시 main thread에서 돌아가야 하는 작업은 아니다.
    - 백그라운드에서 돌아가도 되는 작업이다.

## 변경사항

DIContainer를 아래와 같이 수정한다.

```swift
public actor DIContainer {
    public static let shared = DIContainer()
    private var objects: [String: Any] = [:]
    
    private init() {}
    ...
}
```

## addAction 안에서 Task 처리

> 문제사항 1
> 

```swift
private func configureAddActions() {
    skipButton.addAction(UIAction { [weak self] _ in
        Task { await self?.moveToRegister() }
    }, for: .touchUpInside)
    
    nextButton.addAction(UIAction { [weak self] _ in
        Task { await self?.handleNextButtonTap() }
    }, for: .touchUpInside)
}

private func handleNextButtonTap() async {
    if currentPageIndex == pages.count - 1 {
        await moveToRegister()
    }
    ...
}
```

이렇게 할 경우 맨마지막 페이지에서 스킵과 다음버튼을 동시에 누르면, 한번에 2번의 DIConainer.resolve()가 발생할 수 있다.

`currentPageIndex == pages.count - 1`일때 스킵버튼을 숨김처리 하도록 했다.

이는 PageViewControllerDelegate를 통해서 처리하도록 했다.

```swift
extension OnboardingViewController: UIPageViewControllerDelegate {
    public func pageViewController(
        _ pageViewController: UIPageViewController,
        didFinishAnimating finished: Bool,
        previousViewControllers: [UIViewController],
        transitionCompleted completed: Bool
    ) {
        ...
        skipButton.isHidden = currentPageIndex == pages.count - 1
    }
}
```

### 책 만들기 버튼에 대해 debounce 처리

```swift
private func createViewModelBind() {
    let shared = createViewModel?
            .transform(input: createInput.eraseToAnyPublisher())
            .share()
    
    shared?
        .receive(on: DispatchQueue.main)
        .filter { event in
            if case .moveToNext = event { return false }
            return true
        }
        .sink { [weak self] event in
        ...
        }
        
    shared?
        .receive(on: DispatchQueue.main)
        .filter { event in
            if case .moveToNext = event { return true }
            return false
        }
        .debounce(for: 0.5, scheduler: DispatchQueue.main)
        .sink { [weak self] event in
            if case .moveToNext(let bookID) = event {
                Task { await self?.presentEditBookView(bookID: bookID) }
            }
        }
        .store(in: &cancellables)
}
```

`share()`함수를 통해 구독정보를 공유할 수 있다.
