### PR TITLE
Combine Subject의 Thread와 관련한 문제 해결

### DIFF
--- a/MemorialHouse/MHPresentation/MHPresentation/Source/Register/ViewModel/RegisterViewModel.swift
+++ b/MemorialHouse/MHPresentation/MHPresentation/Source/Register/ViewModel/RegisterViewModel.swift
@@ -45,6 +45,7 @@ public final class RegisterViewModel: ViewModelType {
         output.send(.registerButtonEnabled(isEnabled: !text.isEmpty && text.count < 11))
     }
     
+    @MainActor
     private func registerButtonTapped(with memorialHouseName: String) async {
         do {
             try await createMemorialHouseNameUseCase.execute(with: memorialHouseName)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #174 

<br>

## ⚽️ 트러블 슈팅
<!-- 개발 과정에서 발생한 문제를 노션에 작성하고, 그 내용을 여기에도 올려주세요 ! -->
> [노션 링크](https://kyxxn.notion.site/Combine-Subject-Thread-1ae9adb3262680289350d59899da0df1?pvs=4)

## 문제 상황

1. 등록 화면에서 홈으로 가기 위해서는 "닉네임"을 입력받는다.
2. 닉네임이 입력되면 비동기 메소드 `registerButtonTapped`가 UserDefaults에 닉네임을 저장하고, 끝나면 `output.send(.moveToHome)`을 보낸다.
3. 뷰컨트롤러가 binding 으로 moveToHome을 받으면 홈으로 이동시킨다.

그러나 아래와 같이 Combine Subject에서 문제가 발생한다.

![Image](https://github.com/user-attachments/assets/604d49fd-af00-4ae7-8ed6-890dbd1a2bd2)

---

## 문제 해결

`EXC_BREAKPOINT` 오류가 발생하는 주된 원인은 **스레드 안전성(Thread Safety)** 문제이다.

### Combine의 Subject는 메인 스레드에서 실행

registerButtonTapped의 self.output.send(.moveToHome)는 createMemorialHouseNameUseCase.execute가 실행이 다 끝나야 동작한다.

그리고, registerButtonTapped는 Main 스레드에서 동작하는 게 아니다.

아마 그냥 Task니까 background 우선순위인 비동기 컨텍스트에서 실행될 것이라 본다.

즉, `async/await` 컨텍스트에서 `createMemorialHouseNameUseCase.execute`가 완료된 후 코드가 **메인 스레드가 아닌 다른 스레드에서 재개(resume)** 되기 때문이다.

Combine의 `PassthroughSubject`는 **메인 스레드에서만 안전하게 사용**되어야 하는데, 백그라운드 스레드에서 `send`를 호출하니 문제가 발생하는 것 같다.

### 해결방안 1. DispatchQueue.main.async

그래서 아래처럼 바꿔보았다.

```swift
private func registerButtonTapped(with memorialHouseName: String) async {
    do {
        try await createMemorialHouseNameUseCase.execute(with: memorialHouseName)
        DispatchQueue.main.async { [weak self] in
            self?.output.send(.moveToHome)
        }
    } catch {
        DispatchQueue.main.async { [weak self] in
            self?.output.send(.createFailure(errorMessage: error.localizedDescription))
        }
    }
}
```

그러나, 아래처럼 에러가 발생했다.

`Task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses`

Swift Concurrency의 **actor 격리(actor isolation)** 규칙과 관련된 문제이다.

탈락.

### 해결방안 2. **await MainActor.run**

```swift
private func registerButtonTapped(with memorialHouseName: String) async {
    do {
        try await createMemorialHouseNameUseCase.execute(with: memorialHouseName)
        **await MainActor.run** { [weak self] in
            self?.output.send(.moveToHome)
        }
    } catch {
        await MainActor.run { [weak self] in
            self?.output.send(.createFailure(errorMessage: error.localizedDescription))
        }
    }
}
```

그러나.

`Task-isolated 'self' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses`

결국 똑같다 ..

이 오류들은 self가 기본적으로 Task-isolated 상태인데, await MainActor.run 내의 클로저에서 self를 캡처하면서 Main Actor에서 사용되도록 하려 하기 때문에 발생하는 것이다. 즉, self가 메인 액터에 격리되어 있지 않은 상태에서 Main Actor 컨텍스트로 전환하는 과정에서 경쟁 조건(race condition)의 위험이 있다는 경고이다.

await MainActor.run을 사용해도 self는 여전히 Task-isolated 상태에서 캡처되므로, 이 문제를 근본적으로 해결하려면 해당 메소드를 @.MainActor로 선언해서 self를 메인 액터에 격리된 상태로 만들어야 한다.

### 해결방안 3. @.MainActor

```swift
@.MainActor
private func registerButtonTapped(with memorialHouseName: String) async {
    do {
        try await createMemorialHouseNameUseCase.execute(with: memorialHouseName)
        self.output.send(.moveToHome)
    } catch {
        self.output.send(.createFailure(errorMessage: error.localizedDescription))
    }
}
```

이렇게 해서 Combine의 Subject를 메인 스레드에서 동작 시키며 해결한다.

또한, self가 처음부터 메인 액터에 격리되어 있으므로, output.send를 호출할 때 경쟁 상태 없이 안전하게 메인 스레드에서 실행된다.